### PR TITLE
Make Copper, Brass and Crimson Lanterns respect the fast_lanterns config option.

### DIFF
--- a/src/main/java/net/mehvahdjukaar/supplementaries/block/tiles/OilLanternBlockTile.java
+++ b/src/main/java/net/mehvahdjukaar/supplementaries/block/tiles/OilLanternBlockTile.java
@@ -21,4 +21,9 @@ public class OilLanternBlockTile extends EnhancedLanternBlockTile{
                 super.tick();
         }
     }
+    
+    @Override
+    public boolean hasAnimation() {
+        return this.oldRendererState;
+    }
 }


### PR DESCRIPTION
Copper, brass and crimson lanterns respect the fast_lanterns configuration option for consistency with other lanterns.