### PR TITLE
Updates Mixin Compatibility Level to Java 17

### DIFF
--- a/src/main/resources/supplementaries.mixins.json
+++ b/src/main/resources/supplementaries.mixins.json
@@ -2,7 +2,7 @@
 {
   "minVersion": "0.8",
   "required": true,
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "refmap": "supplementaries.refmap.json",
   "package": "net.mehvahdjukaar.supplementaries.mixins",
   "mixins": [


### PR DESCRIPTION
Fixes this being spammed by the log 
```
[Server thread/DEBUG] [mixin/]: supplementaries.mixins.json:ChunkHolderMixin: Class version 61 required is higher than the class version supported by the current version of Mixin (JAVA_16 supports class version 60)
```