### PR TITLE
Add A Tag To Prevent A Block From Being Framed

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/block/tiles/FrameBlockTile.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/block/tiles/FrameBlockTile.java
@@ -124,6 +124,10 @@ public class FrameBlockTile extends MimicBlockTile {
         if (b == Blocks.BEDROCK) return false;
         if (b == ModRegistry.DAUB_FRAME.get() || b == ModRegistry.DAUB_BRACE.get() || b == ModRegistry.DAUB_CROSS_BRACE.get())
             return false;
+
+        if (b.builtInRegistryHolder().is(ModTags.FRAME_BLOCK_BLACKLIST))
+            return false;
+
         //if (BLOCK_BLACKLIST.contains(block)) { return false; }
         if (b instanceof EntityBlock) {
             return false;

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/reg/ModTags.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/reg/ModTags.java
@@ -37,6 +37,8 @@ public class ModTags {
     public static final TagKey<Block> FLINT_METALS = blockTag("flint_metals");
     public static final TagKey<Block> WALL_LANTERNS_BLACKLIST = blockTag("wall_lanterns_blacklist");
     public static final TagKey<Block> WALL_LANTERNS_WHITELIST = blockTag("wall_lanterns_whitelist");
+    public static final TagKey<Block> FRAME_BLOCK_BLACKLIST = blockTag("frame_block_blacklist")
+
     //item tags
     public static final TagKey<Item> SHULKER_BLACKLIST_TAG = itemTag("shulker_blacklist");
     public static final TagKey<Item> SLINGSHOT_BLACKLIST = itemTag("slingshot_blacklist");


### PR DESCRIPTION
Some blocks, when framed can cause rendering issues as well as not all immovable blocks can feasibly be accounted for so adding a tag would allow for mod developers and or mod pack developers to fix this themselves.

Example Rendering Issue When Framing What Is Currently A "Valid" Block (From Timber Frames Mod)

![image](https://user-images.githubusercontent.com/79579164/219883430-ba3a5dc8-6851-41a3-ace4-88e1e2ea6a95.png)
