### PR TITLE
Fix typo in Dispenser Manager error log

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/block/dispenser/DispenserBehaviorsManager.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/block/dispenser/DispenserBehaviorsManager.java
@@ -155,7 +155,7 @@ public class DispenserBehaviorsManager {
                         DispenserHelper.registerCustomBehavior(new KeyBehavior(i));
                     }
                 } catch (Exception e) {
-                    Supplementaries.LOGGER.warn("Error white registering dispenser behavior for item {}: {}", i, e);
+                    Supplementaries.LOGGER.warn("Error while registering dispenser behavior for item {}: {}", i, e);
                 }
             }
         }


### PR DESCRIPTION
Changed "Error white" to "Error while"