### PR TITLE
Port record-song command to fabric, and adding corrsponding en-us zh-cn zh-tw translations

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/Supplementaries.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/Supplementaries.java
@@ -63,6 +63,7 @@ public class Supplementaries {
         ModEntities.init();
         ModParticles.init();
         ModCommands.init();
+        ModArguments.init();
         ModVillagerTrades.init();
         ModWorldgenRegistry.init();
         ModMapMarkers.init();

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/reg/ModArguments.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/reg/ModArguments.java
@@ -1,0 +1,15 @@
+package net.mehvahdjukaar.supplementaries.reg;
+
+import dev.architectury.injectables.annotations.ExpectPlatform;
+
+public class ModArguments {
+
+    public static void init() {
+        registerArguments();
+    }
+
+    @ExpectPlatform
+    private static void registerArguments() {
+        throw new AssertionError();
+    }
+}

--- a/common/src/main/resources/assets/supplementaries/lang/en_us.json
+++ b/common/src/main/resources/assets/supplementaries/lang/en_us.json
@@ -383,6 +383,8 @@
 
 
   "message.supplementaries.altimeter": "Y: %d",
+  "message.supplementaries.argument.instrument.invalid": "Instrument must be one of %1$s, found %2$s",
+  "message.supplementaries.argument.source.invalid": "Source must be one of %1$s, found %2$s",
   "message.supplementaries.blackboard": "Waxed",
   "message.supplementaries.bubble_blower_tooltip": "Soap: %1$s / %2$s",
   "message.supplementaries.cage.tooltip": "[%s] to place",

--- a/common/src/main/resources/assets/supplementaries/lang/zh_cn.json
+++ b/common/src/main/resources/assets/supplementaries/lang/zh_cn.json
@@ -255,6 +255,8 @@
   "item.supplementaries.antique_ink": "古式墨水",
   "message.supplementaries.command.record.start": "开始录制音符盒",
   "message.supplementaries.command.record.stop": "停止录制音符盒：存储于recorded_songs/%s",
+  "message.supplementaries.argument.instrument.invalid": "乐器必须是 %1$s 之一, 找到的是 %2$s",
+  "message.supplementaries.argument.source.invalid": "来源必须是 %1$s 之一, 找到的是 %2$s",
   "item.supplementaries.wrench": "扳手",
   "block.supplementaries.urn": "瓮",
   "block.supplementaries.stone_tile_stairs": "石瓦楼梯",

--- a/common/src/main/resources/assets/supplementaries/lang/zh_tw.json
+++ b/common/src/main/resources/assets/supplementaries/lang/zh_tw.json
@@ -59,6 +59,11 @@
   "message.supplementaries.command.configs_reloaded": "重新加載配置",
   "block.supplementaries.copper_lantern": "銅燈籠",
 
+  "message.supplementaries.command.record.start": "開始錄製音階盒",
+  "message.supplementaries.command.record.stop": "停止錄製音階盒：存储于recorded_songs/%s",
+  "message.supplementaries.argument.instrument.invalid": "樂器必須是 %1$s 之一, 找到的是 %2$s",
+  "message.supplementaries.argument.source.invalid": "來源必須是 %1$s 之一, 找到的是 %2$s",
+
   "message.supplementaries.hourglass": "接受任何灰塵，沙子或粉末",
   "message.supplementaries.cage": "[Shift] 放置",
   "gui.supplementaries.safe.name": "%1$s's %2$s",

--- a/fabric/src/main/java/net/mehvahdjukaar/supplementaries/common/commands/arguments/fabric/NoteBlockInstrumentArgument.java
+++ b/fabric/src/main/java/net/mehvahdjukaar/supplementaries/common/commands/arguments/fabric/NoteBlockInstrumentArgument.java
@@ -1,0 +1,44 @@
+package net.mehvahdjukaar.supplementaries.common.commands.arguments.fabric;
+
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import net.mehvahdjukaar.supplementaries.common.misc.songs.SongsManager;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.level.block.state.properties.NoteBlockInstrument;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class NoteBlockInstrumentArgument implements ArgumentType<NoteBlockInstrument> {
+
+    private static final DynamicCommandExceptionType INVALID_SONG = new DynamicCommandExceptionType(
+            found -> Component.translatable("message.supplementaries.argument.instrument.invalid", SongsManager.Source.values(), found));
+
+    @Override
+    public NoteBlockInstrument parse(StringReader reader) throws CommandSyntaxException {
+        String string = reader.readUnquotedString();
+        try {
+            return NoteBlockInstrument.valueOf(string);
+        } catch (IllegalArgumentException e) {
+            throw INVALID_SONG.createWithContext(reader, string);
+        }
+    }
+
+    @Override
+    public <S> CompletableFuture<Suggestions> listSuggestions(final CommandContext<S> context, final SuggestionsBuilder builder) {
+        return SharedSuggestionProvider.suggest(Stream.of(NoteBlockInstrument.values()).map(Enum::name), builder);
+    }
+
+    @Override
+    public Collection<String> getExamples() {
+        return Stream.of(NoteBlockInstrument.values()).map(Enum::name).collect(Collectors.toList());
+    }
+}

--- a/fabric/src/main/java/net/mehvahdjukaar/supplementaries/common/commands/arguments/fabric/SourceArgument.java
+++ b/fabric/src/main/java/net/mehvahdjukaar/supplementaries/common/commands/arguments/fabric/SourceArgument.java
@@ -1,0 +1,43 @@
+package net.mehvahdjukaar.supplementaries.common.commands.arguments.fabric;
+
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import net.mehvahdjukaar.supplementaries.common.misc.songs.SongsManager;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.network.chat.Component;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class SourceArgument implements ArgumentType<SongsManager.Source> {
+
+    private static final DynamicCommandExceptionType INVALID_SONG = new DynamicCommandExceptionType(
+            found -> Component.translatable("message.supplementaries.argument.source.invalid", SongsManager.Source.values(), found));
+
+    @Override
+    public SongsManager.Source parse(StringReader reader) throws CommandSyntaxException {
+        String string = reader.readUnquotedString();
+        try {
+            return SongsManager.Source.valueOf(string);
+        } catch (IllegalArgumentException e) {
+            throw INVALID_SONG.createWithContext(reader, string);
+        }
+    }
+
+    @Override
+    public <S> CompletableFuture<Suggestions> listSuggestions(final CommandContext<S> context, final SuggestionsBuilder builder) {
+        return SharedSuggestionProvider.suggest(Stream.of(SongsManager.Source.values()).map(Enum::name), builder);
+    }
+
+    @Override
+    public Collection<String> getExamples() {
+        return Stream.of(SongsManager.Source.values()).map(Enum::name).collect(Collectors.toList());
+    }
+}

--- a/fabric/src/main/java/net/mehvahdjukaar/supplementaries/common/commands/fabric/RecordSongCommandImpl.java
+++ b/fabric/src/main/java/net/mehvahdjukaar/supplementaries/common/commands/fabric/RecordSongCommandImpl.java
@@ -1,17 +1,77 @@
 package net.mehvahdjukaar.supplementaries.common.commands.fabric;
 
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.ArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import net.mehvahdjukaar.supplementaries.common.commands.arguments.fabric.NoteBlockInstrumentArgument;
+import net.mehvahdjukaar.supplementaries.common.commands.arguments.fabric.SourceArgument;
+import net.mehvahdjukaar.supplementaries.common.misc.songs.SongsManager;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.level.block.state.properties.NoteBlockInstrument;
 
 public class RecordSongCommandImpl {
 
     public static ArgumentBuilder<CommandSourceStack, ?> register(CommandBuildContext dispatcher) {
-        return Commands.literal("record").executes(c -> {
-            c.getSource().sendSuccess(() -> Component.literal("Record command has not been implemented for fabric"), false);
-            return 0;
-        });
+        return Commands.literal("record")
+                .requires(cs -> cs.hasPermission(2))
+                .then(Commands.literal("stop").executes(c -> RecordSongCommandImpl.stop(c, "", 0))
+                        .then(Commands.argument("name", StringArgumentType.word())
+                                .executes(c -> RecordSongCommandImpl.stop(c, StringArgumentType.getString(c, "name"), 0))
+                                .then(Commands.argument("speed_up_by", IntegerArgumentType.integer())
+                                        .executes(c -> RecordSongCommandImpl.stop(c,
+                                                StringArgumentType.getString(c, "name"),
+                                                IntegerArgumentType.getInteger(c, "speed_up_by")))
+                                )))
+                .then(Commands.literal("start")
+                        .then(Commands.argument("source", new SourceArgument())
+                                .executes(RecordSongCommandImpl::start)
+                                .then(Commands.argument("instrument_0",
+                                                new NoteBlockInstrumentArgument())
+                                        .executes(c -> RecordSongCommandImpl.start(c, c.getArgument("instrument_0", NoteBlockInstrument.class)))
+                                        .then(Commands.argument("instrument_1",
+                                                        new NoteBlockInstrumentArgument())
+                                                .executes(c -> RecordSongCommandImpl.start(c,
+                                                        c.getArgument("instrument_0", NoteBlockInstrument.class),
+                                                        c.getArgument("instrument_1", NoteBlockInstrument.class)))
+                                                .then(Commands.argument("instrument_2",
+                                                                new NoteBlockInstrumentArgument())
+                                                        .executes(c -> RecordSongCommandImpl.start(c,
+                                                                c.getArgument("instrument_0", NoteBlockInstrument.class),
+                                                                c.getArgument("instrument_1", NoteBlockInstrument.class),
+                                                                c.getArgument("instrument_2", NoteBlockInstrument.class)))
+                                                        .then(Commands.argument("instrument_3",
+                                                                        new NoteBlockInstrumentArgument())
+                                                                .executes(c -> RecordSongCommandImpl.start(c,
+                                                                        c.getArgument("instrument_0", NoteBlockInstrument.class),
+                                                                        c.getArgument("instrument_1", NoteBlockInstrument.class),
+                                                                        c.getArgument("instrument_2", NoteBlockInstrument.class),
+                                                                        c.getArgument("instrument_3", NoteBlockInstrument.class)))
+                                                        ))))));
     }
+
+    public static int stop(CommandContext<CommandSourceStack> context, String name, int speedup) throws CommandSyntaxException {
+
+        String savedName = SongsManager.stopRecording(context.getSource().getLevel(), name, speedup);
+
+        context.getSource().sendSuccess(() -> Component.translatable("message.supplementaries.command.record.stop", savedName), false);
+
+        return 0;
+    }
+
+    public static int start(CommandContext<CommandSourceStack> context, NoteBlockInstrument... whitelist) throws CommandSyntaxException {
+
+        SongsManager.Source source = context.getArgument("source", SongsManager.Source.class);
+        SongsManager.startRecording(source, whitelist);
+
+        context.getSource().sendSuccess(() -> Component.translatable("message.supplementaries.command.record.start"), false);
+
+        return 0;
+    }
+
 }

--- a/fabric/src/main/java/net/mehvahdjukaar/supplementaries/reg/fabric/ModArgumentsImpl.java
+++ b/fabric/src/main/java/net/mehvahdjukaar/supplementaries/reg/fabric/ModArgumentsImpl.java
@@ -1,0 +1,22 @@
+package net.mehvahdjukaar.supplementaries.reg.fabric;
+
+import com.mojang.brigadier.arguments.ArgumentType;
+import net.fabricmc.fabric.api.command.v2.ArgumentTypeRegistry;
+import net.mehvahdjukaar.supplementaries.Supplementaries;
+import net.mehvahdjukaar.supplementaries.common.commands.arguments.fabric.NoteBlockInstrumentArgument;
+import net.mehvahdjukaar.supplementaries.common.commands.arguments.fabric.SourceArgument;
+import net.minecraft.commands.synchronization.ArgumentTypeInfo;
+import net.minecraft.commands.synchronization.SingletonArgumentInfo;
+
+public class ModArgumentsImpl {
+
+    public static void registerArguments() {
+        registerArgument("source", SourceArgument.class, SingletonArgumentInfo.contextFree(SourceArgument::new));
+        registerArgument("note_block_instrument", NoteBlockInstrumentArgument.class, SingletonArgumentInfo.contextFree(NoteBlockInstrumentArgument::new));
+    }
+
+    public static  <A extends ArgumentType<?>, T extends ArgumentTypeInfo.Template<A>> void registerArgument(
+            String name, Class<? extends A> clazz, ArgumentTypeInfo<A, T> serializer) {
+        ArgumentTypeRegistry.registerArgumentType(Supplementaries.res(name), clazz, serializer);
+    }
+}

--- a/forge/src/main/java/net/mehvahdjukaar/supplementaries/reg/forge/ModArgumentsImpl.java
+++ b/forge/src/main/java/net/mehvahdjukaar/supplementaries/reg/forge/ModArgumentsImpl.java
@@ -1,0 +1,9 @@
+package net.mehvahdjukaar.supplementaries.reg.forge;
+
+import java.util.function.Supplier;
+
+public class ModArgumentsImpl {
+
+    private static void registerArguments() {
+    }
+}


### PR DESCRIPTION
Port record-song command to fabric, ensure its functionality same with that on forge.
Instead of re-invent EnumArgument on fabric, two ad-hoc argument classes are added, like vanilla GameModeArgument.
No matter any approach we used, registering ArgumentTypeInfo is still needed.

Tested on fabric, including:

- "/supplementaries record"  -- complaint
- "/supplementaries record start"  -- complaint
- "/supplementaries record start NOTE_BLOCKS BASS"  -- start recording
- "/supplementaries record start NOTE_BL 111"  -- complaint "Source must be one of [NOTE_BLOCKS, SOUND_EVENTS], found NOTE_BL"
- "/supplementaries record stop "  -- stop recording
- "/supplementaries record stop 661 0"  -- stop recording

Not test on forge, can't get minecraft launched even before the change...