### PR TITLE
add IIngredientSubtypeInterpreter for buntings

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/JEICompat.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/JEICompat.java
@@ -11,13 +11,16 @@ import mezz.jei.api.registration.ISubtypeRegistration;
 import net.mehvahdjukaar.supplementaries.Supplementaries;
 import net.mehvahdjukaar.supplementaries.common.items.crafting.SpecialRecipeDisplays;
 import net.mehvahdjukaar.supplementaries.reg.ModRegistry;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.alchemy.Potion;
 import net.minecraft.world.item.alchemy.PotionUtils;
 
 import java.util.List;
+import java.util.Optional;
 
 @JeiPlugin
 public class JEICompat implements IModPlugin {
@@ -39,6 +42,7 @@ public class JEICompat implements IModPlugin {
     @Override
     public void registerItemSubtypes(ISubtypeRegistration registration) {
         registration.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, ModRegistry.BAMBOO_SPIKES_TIPPED_ITEM.get(), SpikesSubtypeInterpreter.INSTANCE);
+        registration.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, ModRegistry.BUNTING.get(), BuntingSubtypeInterpreter.INSTANCE);
     }
 
     public  enum SpikesSubtypeInterpreter implements IIngredientSubtypeInterpreter<ItemStack> {
@@ -56,6 +60,18 @@ public class JEICompat implements IModPlugin {
             }
 
             return stringBuilder.toString();
+        }
+    }
+
+    public  enum BuntingSubtypeInterpreter implements IIngredientSubtypeInterpreter<ItemStack> {
+        INSTANCE;
+
+        public String apply(ItemStack itemStack, UidContext uidContext) {
+
+            Optional<String> color = Optional.ofNullable(itemStack.getTag())
+                    .map(tag -> tag.getString("Color"));
+
+            return color.orElse("");
         }
     }
 


### PR DESCRIPTION
Should correctly display only the recipes  for red bunting when pressing `R` in JEI hovering over red bunting for example.
Could sadly not try it out tho, because I could not get the project to run locally