### PR TITLE
Update loot tables to 1.21

### DIFF
--- a/common/src/main/resources/data/supplementaries/loot_table/blocks/urn_loot/epic.json
+++ b/common/src/main/resources/data/supplementaries/loot_table/blocks/urn_loot/epic.json
@@ -1,138 +1,138 @@
 {
-  "type": "minecraft:block",
-  "pools": [
-    {
-      "rolls": 1.0,
-      "bonus_rolls": 0.0,
-      "entries": [
+    "type": "minecraft:block",
+    "pools": [
         {
-          "type": "minecraft:item",
-          "weight": 5,
-          "functions": [
-            {
-              "function": "minecraft:enchant_with_levels",
-              "levels": {
-                "type": "minecraft:uniform",
-                "min": 34.0,
-                "max": 91.0
-              },
-              "treasure": true
-            },
-            {
-              "function": "minecraft:set_damage",
-              "damage": {
-                "type": "minecraft:uniform",
-                "min": 0.3,
-                "max": 0.8
-              },
-              "add": false
-            },
-            {
-              "function": "supplementaries:random_enchantment",
-              "enchantments": "#minecraft:curse"
-            }
-          ],
-          "name": "minecraft:diamond_helmet"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 5,
-          "functions": [
-            {
-              "function": "minecraft:enchant_with_levels",
-              "levels": {
-                "type": "minecraft:uniform",
-                "min": 34.0,
-                "max": 91.0
-              },
-              "treasure": true
-            },
-            {
-              "function": "minecraft:set_damage",
-              "damage": {
-                "type": "minecraft:uniform",
-                "min": 0.3,
-                "max": 0.8
-              },
-              "add": false
-            },
-            {
-              "function": "supplementaries:random_enchantment",
-              "enchantments": "#minecraft:curse"
-            }
-          ],
-          "name": "minecraft:diamond_boots"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 10,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "type": "minecraft:uniform",
-                "min": 10.0,
-                "max": 64.0
-              },
-              "add": false
-            }
-          ],
-          "name": "minecraft:emerald"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 10,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "type": "minecraft:uniform",
-                "min": 5.0,
-                "max": 8.0
-              },
-              "add": false
-            }
-          ],
-          "name": "minecraft:diamond"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 10,
-          "name": "supplementaries:bomb_blue"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 10,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "type": "minecraft:uniform",
-                "min": 1.0,
-                "max": 4.0
-              },
-              "add": false
-            }
-          ],
-          "name": "minecraft:ender_pearl"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 10,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "type": "minecraft:uniform",
-                "min": 4.0,
-                "max": 12.0
-              },
-              "add": false
-            }
-          ],
-          "name": "minecraft:slime_ball"
+            "rolls": 1.0,
+            "bonus_rolls": 0.0,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 5,
+                    "functions": [
+                        {
+                            "function": "minecraft:enchant_with_levels",
+                            "options": "#minecraft:on_random_loot",
+                            "levels": {
+                                "type": "minecraft:uniform",
+                                "min": 34.0,
+                                "max": 91.0
+                            }
+                        },
+                        {
+                            "function": "minecraft:set_damage",
+                            "damage": {
+                                "type": "minecraft:uniform",
+                                "min": 0.3,
+                                "max": 0.8
+                            },
+                            "add": false
+                        },
+                        {
+                            "function": "minecraft:enchant_randomly",
+                            "options": "#minecraft:curse"
+                        }
+                    ],
+                    "name": "minecraft:diamond_helmet"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 5,
+                    "functions": [
+                        {
+                            "function": "minecraft:enchant_with_levels",
+                            "options": "#minecraft:on_random_loot",
+                            "levels": {
+                                "type": "minecraft:uniform",
+                                "min": 34.0,
+                                "max": 91.0
+                            }
+                        },
+                        {
+                            "function": "minecraft:set_damage",
+                            "damage": {
+                                "type": "minecraft:uniform",
+                                "min": 0.3,
+                                "max": 0.8
+                            },
+                            "add": false
+                        },
+                        {
+                            "function": "minecraft:enchant_randomly",
+                            "options": "#minecraft:curse"
+                        }
+                    ],
+                    "name": "minecraft:diamond_boots"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 10,
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "type": "minecraft:uniform",
+                                "min": 10.0,
+                                "max": 64.0
+                            },
+                            "add": false
+                        }
+                    ],
+                    "name": "minecraft:emerald"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 10,
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "type": "minecraft:uniform",
+                                "min": 5.0,
+                                "max": 8.0
+                            },
+                            "add": false
+                        }
+                    ],
+                    "name": "minecraft:diamond"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 10,
+                    "name": "supplementaries:bomb_blue"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 10,
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "type": "minecraft:uniform",
+                                "min": 1.0,
+                                "max": 4.0
+                            },
+                            "add": false
+                        }
+                    ],
+                    "name": "minecraft:ender_pearl"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 10,
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "type": "minecraft:uniform",
+                                "min": 4.0,
+                                "max": 12.0
+                            },
+                            "add": false
+                        }
+                    ],
+                    "name": "minecraft:slime_ball"
+                }
+            ]
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/common/src/main/resources/data/supplementaries/loot_table/blocks/urn_loot/rare.json
+++ b/common/src/main/resources/data/supplementaries/loot_table/blocks/urn_loot/rare.json
@@ -1,211 +1,212 @@
 {
-  "type": "minecraft:block",
-  "pools": [
-    {
-      "rolls": 1.0,
-      "bonus_rolls": 0.0,
-      "entries": [
+    "type": "minecraft:block",
+    "pools": [
         {
-          "type": "minecraft:item",
-          "weight": 10,
-          "functions": [
-            {
-              "function": "minecraft:enchant_with_levels",
-              "levels": {
-                "type": "minecraft:uniform",
-                "min": 15.0,
-                "max": 35.0
-              },
-              "treasure": true
-            },
-            {
-              "function": "minecraft:set_damage",
-              "damage": {
-                "type": "minecraft:uniform",
-                "min": 0.25,
-                "max": 0.75
-              },
-              "add": false
-            },
-            {
-              "function": "supplementaries:curse_loot"
-            }
-          ],
-          "name": "minecraft:iron_helmet"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 10,
-          "functions": [
-            {
-              "function": "minecraft:enchant_with_levels",
-              "levels": {
-                "type": "minecraft:uniform",
-                "min": 15.0,
-                "max": 35.0
-              },
-              "treasure": true
-            },
-            {
-              "function": "minecraft:set_damage",
-              "damage": {
-                "type": "minecraft:uniform",
-                "min": 0.25,
-                "max": 0.75
-              },
-              "add": false
-            },
-            {
-              "function": "supplementaries:random_enchantment",
-              "enchantments": "#minecraft:curse"
-            }
-          ],
-          "name": "minecraft:iron_boots"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 5,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "type": "minecraft:uniform",
-                "min": 1.0,
-                "max": 4.0
-              },
-              "add": false
-            }
-          ],
-          "name": "minecraft:diamond"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 15,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "type": "minecraft:uniform",
-                "min": 2.0,
-                "max": 8.0
-              },
-              "add": false
-            }
-          ],
-          "name": "minecraft:emerald"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 10,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "type": "minecraft:uniform",
-                "min": 3.0,
-                "max": 8.0
-              },
-              "add": false
-            }
-          ],
-          "name": "minecraft:raw_iron"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 10,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "type": "minecraft:uniform",
-                "min": 3.0,
-                "max": 8.0
-              },
-              "add": false
-            }
-          ],
-          "name": "minecraft:raw_copper"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 10,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "type": "minecraft:uniform",
-                "min": 3.0,
-                "max": 8.0
-              },
-              "add": false
-            }
-          ],
-          "name": "minecraft:raw_gold"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 12,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "type": "minecraft:uniform",
-                "min": 4.0,
-                "max": 16.0
-              },
-              "add": false
-            }
-          ],
-          "name": "minecraft:amethyst_shard"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 10,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "type": "minecraft:uniform",
-                "min": 4.0,
-                "max": 12.0
-              },
-              "add": false
-            }
-          ],
-          "name": "minecraft:lapis_lazuli"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 7,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "type": "minecraft:uniform",
-                "min": 2.0,
-                "max": 5.0
-              },
-              "add": false
-            }
-          ],
-          "name": "supplementaries:bomb"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 2,
-          "name": "minecraft:skeleton_skull"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 2,
-          "name": "minecraft:zombie_head"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 5,
-          "name": "minecraft:bundle"
+            "rolls": 1.0,
+            "bonus_rolls": 0.0,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 10,
+                    "functions": [
+                        {
+                            "function": "minecraft:enchant_with_levels",
+                            "options": "#minecraft:on_random_loot",
+                            "levels": {
+                                "type": "minecraft:uniform",
+                                "min": 15.0,
+                                "max": 35.0
+                            }
+                        },
+                        {
+                            "function": "minecraft:set_damage",
+                            "damage": {
+                                "type": "minecraft:uniform",
+                                "min": 0.25,
+                                "max": 0.75
+                            },
+                            "add": false
+                        },
+                        {
+                            "function": "minecraft:enchant_randomly",
+                            "options": "#minecraft:curse"
+                        }
+                    ],
+                    "name": "minecraft:iron_helmet"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 10,
+                    "functions": [
+                        {
+                            "function": "minecraft:enchant_with_levels",
+                            "options": "#minecraft:on_random_loot",
+                            "levels": {
+                                "type": "minecraft:uniform",
+                                "min": 15.0,
+                                "max": 35.0
+                            }
+                        },
+                        {
+                            "function": "minecraft:set_damage",
+                            "damage": {
+                                "type": "minecraft:uniform",
+                                "min": 0.25,
+                                "max": 0.75
+                            },
+                            "add": false
+                        },
+                        {
+                            "function": "minecraft:enchant_randomly",
+                            "options": "#minecraft:curse"
+                        }
+                    ],
+                    "name": "minecraft:iron_boots"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 5,
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "type": "minecraft:uniform",
+                                "min": 1.0,
+                                "max": 4.0
+                            },
+                            "add": false
+                        }
+                    ],
+                    "name": "minecraft:diamond"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 15,
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "type": "minecraft:uniform",
+                                "min": 2.0,
+                                "max": 8.0
+                            },
+                            "add": false
+                        }
+                    ],
+                    "name": "minecraft:emerald"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 10,
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "type": "minecraft:uniform",
+                                "min": 3.0,
+                                "max": 8.0
+                            },
+                            "add": false
+                        }
+                    ],
+                    "name": "minecraft:raw_iron"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 10,
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "type": "minecraft:uniform",
+                                "min": 3.0,
+                                "max": 8.0
+                            },
+                            "add": false
+                        }
+                    ],
+                    "name": "minecraft:raw_copper"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 10,
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "type": "minecraft:uniform",
+                                "min": 3.0,
+                                "max": 8.0
+                            },
+                            "add": false
+                        }
+                    ],
+                    "name": "minecraft:raw_gold"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 12,
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "type": "minecraft:uniform",
+                                "min": 4.0,
+                                "max": 16.0
+                            },
+                            "add": false
+                        }
+                    ],
+                    "name": "minecraft:amethyst_shard"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 10,
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "type": "minecraft:uniform",
+                                "min": 4.0,
+                                "max": 12.0
+                            },
+                            "add": false
+                        }
+                    ],
+                    "name": "minecraft:lapis_lazuli"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 7,
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "type": "minecraft:uniform",
+                                "min": 2.0,
+                                "max": 5.0
+                            },
+                            "add": false
+                        }
+                    ],
+                    "name": "supplementaries:bomb"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 2,
+                    "name": "minecraft:skeleton_skull"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 2,
+                    "name": "minecraft:zombie_head"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 5,
+                    "name": "minecraft:bundle"
+                }
+            ]
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/common/src/main/resources/data/supplementaries/loot_table/blocks/urn_loot/urn_loot.json
+++ b/common/src/main/resources/data/supplementaries/loot_table/blocks/urn_loot/urn_loot.json
@@ -1,35 +1,35 @@
 {
-  "type": "minecraft:block",
-  "pools": [
-    {
-      "rolls": 1.0,
-      "bonus_rolls": 0.0,
-      "entries": [
+    "type": "minecraft:block",
+    "pools": [
         {
-          "type": "minecraft:loot_table",
-          "weight": 60,
-          "quality": -5,
-          "name": "supplementaries:blocks/urn_loot/common"
-        },
-        {
-          "type": "minecraft:loot_table",
-          "weight": 32,
-          "quality": -2,
-          "name": "supplementaries:blocks/urn_loot/uncommon"
-        },
-        {
-          "type": "minecraft:loot_table",
-          "weight": 7,
-          "quality": 2,
-          "name": "supplementaries:blocks/urn_loot/rare"
-        },
-        {
-          "type": "minecraft:loot_table",
-          "weight": 1,
-          "quality": 5,
-          "name": "supplementaries:blocks/urn_loot/epic"
+            "rolls": 1.0,
+            "bonus_rolls": 0.0,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "weight": 60,
+                    "quality": -5,
+                    "value": "supplementaries:blocks/urn_loot/common"
+                },
+                {
+                    "type": "minecraft:loot_table",
+                    "weight": 32,
+                    "quality": -2,
+                    "value": "supplementaries:blocks/urn_loot/uncommon"
+                },
+                {
+                    "type": "minecraft:loot_table",
+                    "weight": 7,
+                    "quality": 2,
+                    "value": "supplementaries:blocks/urn_loot/rare"
+                },
+                {
+                    "type": "minecraft:loot_table",
+                    "weight": 1,
+                    "quality": 5,
+                    "value": "supplementaries:blocks/urn_loot/epic"
+                }
+            ]
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/common/src/main/resources/data/supplementaries/loot_table/inject/end_city_stasis.json
+++ b/common/src/main/resources/data/supplementaries/loot_table/inject/end_city_stasis.json
@@ -1,26 +1,26 @@
 {
-  "pools": [
-    {
-      "rolls": 1,
-      "conditions": [
+    "pools": [
         {
-          "condition": "random_chance",
-          "chance": 0.25
+            "rolls": 1,
+            "conditions": [
+                {
+                    "condition": "random_chance",
+                    "chance": 0.25
+                }
+            ],
+            "entries": [
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "minecraft:book",
+                    "functions": [
+                        {
+                            "function": "minecraft:enchant_randomly",
+                            "options": "supplementaries:stasis"
+                        }
+                    ]
+                }
+            ]
         }
-      ],
-      "entries": [
-        {
-          "type": "item",
-          "weight": 1,
-          "name": "minecraft:enchanted_book",
-          "functions": [
-            {
-              "function": "set_components",
-              "tag": "{StoredEnchantments:[{lvl:1s,id:\"supplementaries:stasis\"}]}"
-            }
-          ]
-        }
-      ]
-    }
-  ]
+    ]
 }

--- a/common/src/main/resources/data/supplementaries/loot_table/inject/temple_spikes.json
+++ b/common/src/main/resources/data/supplementaries/loot_table/inject/temple_spikes.json
@@ -27,8 +27,8 @@
                             "function": "supplementaries:set_charges",
                             "charges": {
                                 "type": "minecraft:uniform",
-                                "min": 3,
-                                "max": 14
+                                "min_inclusive": 20,
+                                "max_inclusive": 200
                             }
                         }
                     ]

--- a/common/src/main/resources/data/supplementaries/loot_table/inject/temple_spikes.json
+++ b/common/src/main/resources/data/supplementaries/loot_table/inject/temple_spikes.json
@@ -1,44 +1,39 @@
 {
-  "pools": [
-    {
-      "rolls": 1,
-      "conditions": [
+    "pools": [
         {
-          "condition": "random_chance",
-          "chance": 0.38
-        }
-      ],
-      "entries": [
-        {
-          "type": "item",
-          "weight": 4,
-          "name": "supplementaries:bamboo_spikes"
-        },
-        {
-          "type": "item",
-          "weight": 3,
-          "name": "supplementaries:bamboo_spikes_tipped",
-          "functions": [
-            {
-              "function": "set_components",
-              "components": [
+            "rolls": 1,
+            "conditions": [
                 {
-                  "type": "minecraft:potion_content",
-                  "potion": "minecraft:poison"
+                    "condition": "random_chance",
+                    "chance": 0.38
                 }
-              ]
-            },
-            {
-              "function": "supplementaries:set_charges",
-              "charges": {
-                "type": "uniform",
-                "min_inclusive": 20,
-                "max_inclusive": 200
-              }
-            }
-          ]
+            ],
+            "entries": [
+                {
+                    "type": "item",
+                    "weight": 4,
+                    "name": "supplementaries:bamboo_spikes"
+                },
+                {
+                    "type": "item",
+                    "weight": 3,
+                    "name": "supplementaries:bamboo_spikes_tipped",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_potion",
+                            "id": "minecraft:poison"
+                        },
+                        {
+                            "function": "supplementaries:set_charges",
+                            "charges": {
+                                "type": "minecraft:uniform",
+                                "min": 3,
+                                "max": 14
+                            }
+                        }
+                    ]
+                }
+            ]
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/common/src/main/resources/data/supplementaries/loot_table/inject/test.json
+++ b/common/src/main/resources/data/supplementaries/loot_table/inject/test.json
@@ -1,23 +1,23 @@
 {
-  "type": "minecraft:chest",
-  "pools": [
-    {
-      "rolls": 1,
-      "entries": [
+    "type": "minecraft:chest",
+    "pools": [
         {
-          "type": "minecraft:item",
-          "name": "minecraft:map",
-          "functions": [
-            {
-              "function": "minecraft:exploration_map",
-              "destination": "minecraft:village",
-              "custom_decoration": "supplementaries:igloo",
-              "zoom": 2,
-              "skip_existing_chunks": true
-            }
-          ]
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "name": "minecraft:map",
+                    "functions": [
+                        {
+                            "function": "minecraft:exploration_map",
+                            "destination": "minecraft:village",
+                            "decoration": "minecraft:red_x",
+                            "zoom": 2,
+                            "skip_existing_chunks": true
+                        }
+                    ]
+                }
+            ]
         }
-      ]
-    }
-  ]
+    ]
 }


### PR DESCRIPTION
Notes:
* Had to use a generic map marker decoration since `supplementaries:igloo` doesn't exist on 1.21 yet on `supplementaries:inject/test`