### PR TITLE
Arclight server compatibility fix

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/ArclightMixinPlugin.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/ArclightMixinPlugin.java
@@ -1,0 +1,74 @@
+package net.mehvahdjukaar.supplementaries;
+
+import com.google.common.collect.ImmutableMap;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+import org.spongepowered.asm.service.MixinService;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+public final  class ArclightMixinPlugin implements IMixinConfigPlugin {
+    private static final Supplier<Boolean> TRUE = () -> true;
+
+    private static final Map<String, Supplier<Boolean>> CONDITIONS = ImmutableMap.of(
+        "net.mehvahdjukaar.supplementaries.mixins.CreeperArclightMixin", () -> {
+            try {
+                MixinService.getService().getBytecodeProvider().getClassNode("io.izzel.arclight.common.mixin.core.world.entity.monster.CreeperMixin");
+            } catch (Exception e) {
+                return false;
+            }
+
+            return true;
+        }, "net.mehvahdjukaar.supplementaries.mixins.CreeperMixin", () -> {
+            try {
+                MixinService.getService().getBytecodeProvider().getClassNode("io.izzel.arclight.common.mixin.core.world.entity.monster.CreeperMixin");
+            } catch (Exception e) {
+                return true;
+            }
+
+            return false;
+        }
+    );
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        return CONDITIONS.getOrDefault(mixinClassName, TRUE).get();
+    }
+
+    // Boilerplate
+
+    @Override
+    public void onLoad(String mixinPackage) {
+
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+}

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/mixins/CreeperArclightMixin.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/mixins/CreeperArclightMixin.java
@@ -1,0 +1,71 @@
+package net.mehvahdjukaar.supplementaries.mixins;
+
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import net.mehvahdjukaar.supplementaries.common.entities.IPartyCreeper;
+import net.mehvahdjukaar.supplementaries.common.network.ClientBoundParticlePacket;
+import net.mehvahdjukaar.supplementaries.common.network.ModNetwork;
+import net.mehvahdjukaar.supplementaries.common.network.SyncPartyCreeperPacket;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.monster.Creeper;
+import net.minecraft.world.entity.monster.Monster;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Creeper.class)
+public abstract class CreeperArclightMixin extends Monster implements IPartyCreeper {
+
+    @Unique
+    private boolean supplementaries$festive = false;
+
+    @Override
+    public boolean supplementaries$isFestive() {
+        return this.supplementaries$festive;
+    }
+
+    @Override
+    public void supplementaries$setFestive(boolean festive) {
+        this.supplementaries$festive = festive;
+        if (!level().isClientSide) {
+            //only needed when entity is alraedy spawned
+            ModNetwork.CHANNEL.sentToAllClientPlayersTrackingEntity(this,
+                    new SyncPartyCreeperPacket(this));
+        }
+    }
+
+    protected CreeperArclightMixin(EntityType<? extends Monster> entityType, Level level) {
+        super(entityType, level);
+    }
+
+    @WrapWithCondition(method = "explodeCreeper", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;explode(Lnet/minecraft/world/entity/Entity;DDDFZLnet/minecraft/world/level/Level$ExplosionInteraction;)Lnet/minecraft/world/level/Explosion;"))
+    public boolean supp$checkPartyCreeper(Level instance, Entity source, double x, double y, double z, float radius, boolean fire, Level.ExplosionInteraction explosionInteraction) {
+        if (supplementaries$festive) {
+            ClientBoundParticlePacket packet = new ClientBoundParticlePacket(new Vec3(x, y + this.getBbHeight() / 2, z), ClientBoundParticlePacket.Type.CONFETTI_EXPLOSION,
+                    (int) radius, null);
+
+            ModNetwork.CHANNEL.sentToAllClientPlayersTrackingEntity(this, packet);
+            return false;
+        }
+        return true;
+    }
+
+    @Inject(method = "addAdditionalSaveData", at = @At("TAIL"))
+    public void supp$addPartyCreeperData(CompoundTag compound, CallbackInfo ci) {
+        if (this.supplementaries$festive) {
+            compound.putBoolean("Party", true);
+        }
+    }
+
+    @Inject(method = "readAdditionalSaveData", at = @At("TAIL"))
+    public void supp$readPartyCreeperData(CompoundTag compound, CallbackInfo ci) {
+        if (compound.contains("Party")) {
+            this.supplementaries$setFestive(compound.getBoolean("Party"));
+        }
+    }
+}

--- a/common/src/main/resources/mixins.arclight.json
+++ b/common/src/main/resources/mixins.arclight.json
@@ -1,0 +1,16 @@
+{
+  "compatibilityLevel": "JAVA_17",
+  "minVersion": "0.8",
+  "package": "net.mehvahdjukaar.supplementaries.mixins",
+  "required": true,
+  "plugin": "net.mehvahdjukaar.supplementaries.ArclightMixinPlugin",
+
+  "mixins": [
+    "CreeperMixin",
+    "CreeperArclightMixin"
+  ],
+
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/common/src/main/resources/supplementaries-common.mixins.json
+++ b/common/src/main/resources/supplementaries-common.mixins.json
@@ -17,7 +17,6 @@
     "CartographyTableMixin",
     "CatSitOnBlockGoalMixin",
     "ComparatorBlockMixin",
-    "CreeperMixin",
     "CrossbowItemRopeMixin",
     "EndermanMixin",
     "EntityMixin",


### PR DESCRIPTION
I've added MixinPlugin which tries to load Arclight mixin Class. And if it does, then it uses special mixin (because Arclight overwrites target mixin). If it doesn't - it loads base Class.