### PR TITLE
Prevents lunch_basket_blacklist.json item tag from being "cooked"

### DIFF
--- a/common/src/main/resources/data/supplementaries/tags/items/lunch_basket_blacklist.json
+++ b/common/src/main/resources/data/supplementaries/tags/items/lunch_basket_blacklist.json
@@ -1,7 +1,7 @@
 {
   "replace": false,
   "values": [
-    {"id":"supplementaries:lunch_basket","required":true},
-    {"id":"potionbundles:potion_bundle","required":true}
+    {"id":"supplementaries:lunch_basket","required":false},
+    {"id":"potionbundles:potion_bundle","required":false}
   ]
 }


### PR DESCRIPTION
## Goals
* Sets all items within the tag to `"required": false` to prevent breaking the tag if items do not exist