### PR TITLE
Add ShulkerBoxTooltip Compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,6 +182,8 @@ allprojects {
         maven {
             url = "https://maven.blamejared.com/"
         }
+
+        maven { url "https://maven.misterpemodder.com/libs-release/" } // ShulkerBoxTooltip
     }
 
     tasks.withType(JavaCompile) {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     modCompileOnly("maven.modrinth:frozenlib:1.7.4-mc1.20.1")
     modImplementation ("curse.maven:amendments-896746:5692774")
     modImplementation ("curse.maven:appleskin-248787:4770828")
-
+    modCompileOnly("com.misterpemodder:shulkerboxtooltip-common:${shulker_box_tooltip_version}") { transitive false }
 }
 
 publishing {

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/items/SackItem.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/items/SackItem.java
@@ -7,6 +7,7 @@ import net.mehvahdjukaar.supplementaries.configs.CommonConfigs;
 import net.mehvahdjukaar.supplementaries.integration.CompatHandler;
 import net.mehvahdjukaar.supplementaries.integration.QuarkClientCompat;
 import net.mehvahdjukaar.supplementaries.integration.QuarkCompat;
+import net.mehvahdjukaar.supplementaries.integration.ShulkerBoxTooltipCompat;
 import net.mehvahdjukaar.supplementaries.reg.ModRegistry;
 import net.mehvahdjukaar.supplementaries.reg.ModTags;
 import net.minecraft.nbt.CompoundTag;
@@ -61,7 +62,9 @@ public class SackItem extends BlockItem {
     @Override
     public void appendHoverText(ItemStack stack, @Nullable Level worldIn, List<Component> tooltip, TooltipFlag flagIn) {
         super.appendHoverText(stack, worldIn, tooltip, flagIn);
-        if (!CompatHandler.QUARK || !QuarkClientCompat.canRenderQuarkTooltip()) {
+        boolean quarkTooltips = CompatHandler.QUARK && QuarkClientCompat.canRenderQuarkTooltip();
+        boolean sbtTooltips = CompatHandler.SHULKER_BOX_TOOLTIP && ShulkerBoxTooltipCompat.isPreviewAvailable(stack);
+        if (!quarkTooltips && !sbtTooltips) {
             CompoundTag tag = stack.getTagElement("BlockEntityTag");
             if (tag != null) {
                 ItemsUtil.addShulkerLikeTooltips(tag, tooltip);

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/items/SackItem.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/items/SackItem.java
@@ -62,9 +62,9 @@ public class SackItem extends BlockItem {
     @Override
     public void appendHoverText(ItemStack stack, @Nullable Level worldIn, List<Component> tooltip, TooltipFlag flagIn) {
         super.appendHoverText(stack, worldIn, tooltip, flagIn);
-        boolean quarkTooltips = CompatHandler.QUARK && QuarkClientCompat.canRenderQuarkTooltip();
-        boolean sbtTooltips = CompatHandler.SHULKER_BOX_TOOLTIP && ShulkerBoxTooltipCompat.isPreviewAvailable(stack);
-        if (!quarkTooltips && !sbtTooltips) {
+        boolean quarkTooltip = CompatHandler.QUARK && QuarkClientCompat.canRenderQuarkTooltip();
+        boolean sbtTooltip = CompatHandler.SHULKER_BOX_TOOLTIP && ShulkerBoxTooltipCompat.hasPreviewProvider(stack);
+        if (!quarkTooltip && !sbtTooltip) {
             CompoundTag tag = stack.getTagElement("BlockEntityTag");
             if (tag != null) {
                 ItemsUtil.addShulkerLikeTooltips(tag, tooltip);
@@ -100,7 +100,9 @@ public class SackItem extends BlockItem {
 
     @Override
     public Optional<TooltipComponent> getTooltipImage(ItemStack pStack) {
-        if (CompatHandler.QUARK && QuarkClientCompat.canRenderQuarkTooltip()) {
+        boolean quarkTooltip = CompatHandler.QUARK && QuarkClientCompat.canRenderQuarkTooltip();
+        boolean sbtTooltip = CompatHandler.SHULKER_BOX_TOOLTIP && ShulkerBoxTooltipCompat.hasPreviewProvider(pStack);
+        if (quarkTooltip && !sbtTooltip) {
             CompoundTag cmp = pStack.getTagElement("BlockEntityTag");
             if (cmp != null && !cmp.contains("LootTable")) {
                 return Optional.of(new InventoryTooltip(cmp, this, CommonConfigs.Functional.SACK_SLOTS.get()));

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/items/SafeItem.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/items/SafeItem.java
@@ -1,22 +1,19 @@
 package net.mehvahdjukaar.supplementaries.common.items;
 
-
 import net.mehvahdjukaar.supplementaries.common.items.tooltip_components.InventoryTooltip;
 import net.mehvahdjukaar.supplementaries.common.utils.ItemsUtil;
 import net.mehvahdjukaar.supplementaries.integration.CompatHandler;
 import net.mehvahdjukaar.supplementaries.integration.QuarkClientCompat;
 import net.mehvahdjukaar.supplementaries.integration.QuarkCompat;
+import net.mehvahdjukaar.supplementaries.integration.ShulkerBoxTooltipCompat;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
 import net.minecraft.world.entity.SlotAccess;
-import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.ClickAction;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.ItemUtils;
 import net.minecraft.world.level.block.Block;
 
 import java.util.Optional;
@@ -46,7 +43,9 @@ public class SafeItem extends BlockItem {
     @Override
     @SuppressWarnings("ConstantConditions")
     public Optional<TooltipComponent> getTooltipImage(ItemStack pStack) {
-        if (CompatHandler.QUARK && QuarkClientCompat.canRenderBlackboardTooltip()) {
+        boolean quarkTooltip = CompatHandler.QUARK && QuarkClientCompat.canRenderBlackboardTooltip();
+        boolean sbtTooltip = CompatHandler.SHULKER_BOX_TOOLTIP && ShulkerBoxTooltipCompat.hasPreviewProvider(pStack);
+        if (quarkTooltip && !sbtTooltip) {
             CompoundTag cmp = pStack.getTagElement("BlockEntityTag");
             if (cmp != null && !cmp.contains("LootTable")) {
                 return Optional.of(new InventoryTooltip(cmp, this, 27));

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/CompatHandler.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/CompatHandler.java
@@ -80,6 +80,7 @@ public class CompatHandler {
     public static final boolean FARMERS_RESPRITE = isLoaded("farmersrespite");
     public static final boolean ARCHITECTS_PALETTE = isLoaded("architects_palette");
     public static final boolean OPTIFINE;
+    public static final boolean SHULKER_BOX_TOOLTIP = isLoaded("shulkerboxtooltip");
 
     static {
         boolean of = false;

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/ShulkerBoxTooltipCompat.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/ShulkerBoxTooltipCompat.java
@@ -1,0 +1,35 @@
+package net.mehvahdjukaar.supplementaries.integration;
+
+import com.misterpemodder.shulkerboxtooltip.api.PreviewContext;
+import com.misterpemodder.shulkerboxtooltip.api.ShulkerBoxTooltipApi;
+import com.misterpemodder.shulkerboxtooltip.api.provider.PreviewProvider;
+import com.misterpemodder.shulkerboxtooltip.api.provider.PreviewProviderRegistry;
+import dev.architectury.injectables.annotations.ExpectPlatform;
+import net.mehvahdjukaar.supplementaries.Supplementaries;
+import net.mehvahdjukaar.supplementaries.integration.shulkerboxtooltip.SackPreviewProvider;
+import net.mehvahdjukaar.supplementaries.integration.shulkerboxtooltip.SafePreviewProvider;
+import net.mehvahdjukaar.supplementaries.reg.ModRegistry;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+
+public class ShulkerBoxTooltipCompat implements ShulkerBoxTooltipApi {
+
+    @Override
+    public void registerProviders(PreviewProviderRegistry registry) {
+        registry.register(new ResourceLocation(Supplementaries.MOD_ID, "safe"), new SafePreviewProvider(),
+            ModRegistry.SAFE_ITEM.get());
+        registry.register(new ResourceLocation(Supplementaries.MOD_ID, "sack"), new SackPreviewProvider(),
+            ModRegistry.SACK_ITEM.get());
+    }
+
+    public static boolean isPreviewAvailable(ItemStack stack) {
+        PreviewProvider provider = ShulkerBoxTooltipApi.getPreviewProviderForStack(stack);
+        return provider != null && provider.shouldDisplay(PreviewContext.of(stack));
+    }
+
+    @ExpectPlatform
+    public static void registerPlugin() {
+        throw new AssertionError();
+    }
+
+}

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/ShulkerBoxTooltipCompat.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/ShulkerBoxTooltipCompat.java
@@ -1,8 +1,6 @@
 package net.mehvahdjukaar.supplementaries.integration;
 
-import com.misterpemodder.shulkerboxtooltip.api.PreviewContext;
 import com.misterpemodder.shulkerboxtooltip.api.ShulkerBoxTooltipApi;
-import com.misterpemodder.shulkerboxtooltip.api.provider.PreviewProvider;
 import com.misterpemodder.shulkerboxtooltip.api.provider.PreviewProviderRegistry;
 import dev.architectury.injectables.annotations.ExpectPlatform;
 import net.mehvahdjukaar.supplementaries.Supplementaries;
@@ -22,9 +20,8 @@ public class ShulkerBoxTooltipCompat implements ShulkerBoxTooltipApi {
             ModRegistry.SACK_ITEM.get());
     }
 
-    public static boolean isPreviewAvailable(ItemStack stack) {
-        PreviewProvider provider = ShulkerBoxTooltipApi.getPreviewProviderForStack(stack);
-        return provider != null && provider.shouldDisplay(PreviewContext.of(stack));
+    public static boolean hasPreviewProvider(ItemStack stack) {
+        return ShulkerBoxTooltipApi.getPreviewProviderForStack(stack) != null;
     }
 
     @ExpectPlatform

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/SackPreviewProvider.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/SackPreviewProvider.java
@@ -2,9 +2,15 @@ package net.mehvahdjukaar.supplementaries.integration.shulkerboxtooltip;
 
 import com.misterpemodder.shulkerboxtooltip.api.PreviewContext;
 import com.misterpemodder.shulkerboxtooltip.api.provider.BlockEntityPreviewProvider;
+import com.misterpemodder.shulkerboxtooltip.api.renderer.PreviewRenderer;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.mehvahdjukaar.supplementaries.common.block.tiles.SackBlockTile;
 
 public final class SackPreviewProvider extends BlockEntityPreviewProvider {
+
+    @Environment(EnvType.CLIENT)
+    private static final PreviewRenderer RENDERER = new VariableSizePreviewRenderer(SackBlockTile::getUnlockedSlots);
 
     public SackPreviewProvider() {
         super(SackBlockTile.getUnlockedSlots(), true);
@@ -13,6 +19,12 @@ public final class SackPreviewProvider extends BlockEntityPreviewProvider {
     @Override
     public int getInventoryMaxSize(PreviewContext context) {
         return SackBlockTile.getUnlockedSlots();
+    }
+
+    @Override
+    @Environment(EnvType.CLIENT)
+    public PreviewRenderer getRenderer() {
+        return RENDERER;
     }
 
 }

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/SackPreviewProvider.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/SackPreviewProvider.java
@@ -1,0 +1,18 @@
+package net.mehvahdjukaar.supplementaries.integration.shulkerboxtooltip;
+
+import com.misterpemodder.shulkerboxtooltip.api.PreviewContext;
+import com.misterpemodder.shulkerboxtooltip.api.provider.BlockEntityPreviewProvider;
+import net.mehvahdjukaar.supplementaries.common.block.tiles.SackBlockTile;
+
+public final class SackPreviewProvider extends BlockEntityPreviewProvider {
+
+    public SackPreviewProvider() {
+        super(SackBlockTile.getUnlockedSlots(), true);
+    }
+
+    @Override
+    public int getInventoryMaxSize(PreviewContext context) {
+        return SackBlockTile.getUnlockedSlots();
+    }
+
+}

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/SafePreviewProvider.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/SafePreviewProvider.java
@@ -1,14 +1,21 @@
 package net.mehvahdjukaar.supplementaries.integration.shulkerboxtooltip;
 
+import com.google.common.base.Suppliers;
 import com.misterpemodder.shulkerboxtooltip.api.PreviewContext;
 import com.misterpemodder.shulkerboxtooltip.api.provider.BlockEntityPreviewProvider;
 import net.mehvahdjukaar.supplementaries.common.block.tiles.SafeBlockTile;
-import net.mehvahdjukaar.supplementaries.common.utils.ItemsUtil;
+import net.mehvahdjukaar.supplementaries.common.items.SafeItem;
+import net.mehvahdjukaar.supplementaries.reg.ModRegistry;
+import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.entity.BlockEntity;
+
+import java.util.function.Supplier;
 
 public final class SafePreviewProvider extends BlockEntityPreviewProvider {
+
+    private static final Supplier<SafeBlockTile> DUMMY_SAFE_TILE = Suppliers.memoize(() -> new SafeBlockTile(BlockPos.ZERO,
+        ModRegistry.SAFE.get().defaultBlockState()));
 
     public SafePreviewProvider() {
         super(27, true);
@@ -20,13 +27,12 @@ public final class SafePreviewProvider extends BlockEntityPreviewProvider {
             return false;
         }
         ItemStack stack = context.stack();
-        CompoundTag beTag = stack.getTagElement("BlockEntityTag");
-        BlockEntity te = ItemsUtil.loadBlockEntityFromItem(beTag, stack.getItem());
-        if (te instanceof SafeBlockTile safe) {
-            return safe.canPlayerOpen(context.owner(), false);
-        } else {
-            return false;
+        if (stack.getItem() instanceof SafeItem) {
+            CompoundTag beTag = stack.getTagElement("BlockEntityTag");
+            DUMMY_SAFE_TILE.get().load(beTag);
+            return DUMMY_SAFE_TILE.get().canPlayerOpen(context.owner(), false);
         }
+        return false;
     }
 
 }

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/SafePreviewProvider.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/SafePreviewProvider.java
@@ -1,0 +1,11 @@
+package net.mehvahdjukaar.supplementaries.integration.shulkerboxtooltip;
+
+import com.misterpemodder.shulkerboxtooltip.api.provider.BlockEntityPreviewProvider;
+
+public final class SafePreviewProvider extends BlockEntityPreviewProvider {
+
+    public SafePreviewProvider() {
+        super(27, true);
+    }
+
+}

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/SafePreviewProvider.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/SafePreviewProvider.java
@@ -1,11 +1,32 @@
 package net.mehvahdjukaar.supplementaries.integration.shulkerboxtooltip;
 
+import com.misterpemodder.shulkerboxtooltip.api.PreviewContext;
 import com.misterpemodder.shulkerboxtooltip.api.provider.BlockEntityPreviewProvider;
+import net.mehvahdjukaar.supplementaries.common.block.tiles.SafeBlockTile;
+import net.mehvahdjukaar.supplementaries.common.utils.ItemsUtil;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
 
 public final class SafePreviewProvider extends BlockEntityPreviewProvider {
 
     public SafePreviewProvider() {
         super(27, true);
+    }
+
+    @Override
+    public boolean shouldDisplay(PreviewContext context) {
+        if (!super.shouldDisplay(context)) {
+            return false;
+        }
+        ItemStack stack = context.stack();
+        CompoundTag beTag = stack.getTagElement("BlockEntityTag");
+        BlockEntity te = ItemsUtil.loadBlockEntityFromItem(beTag, stack.getItem());
+        if (te instanceof SafeBlockTile safe) {
+            return safe.canPlayerOpen(context.owner(), false);
+        } else {
+            return false;
+        }
     }
 
 }

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/VariableSizePreviewRenderer.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/VariableSizePreviewRenderer.java
@@ -1,0 +1,164 @@
+package net.mehvahdjukaar.supplementaries.integration.shulkerboxtooltip;
+
+import com.misterpemodder.shulkerboxtooltip.api.PreviewContext;
+import com.misterpemodder.shulkerboxtooltip.api.PreviewType;
+import com.misterpemodder.shulkerboxtooltip.api.provider.PreviewProvider;
+import com.misterpemodder.shulkerboxtooltip.api.renderer.PreviewRenderer;
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.mehvahdjukaar.supplementaries.common.inventories.VariableSizeContainerMenu;
+import net.mehvahdjukaar.supplementaries.reg.ModTextures;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * A PreviewRenderer that mimics the way slots are placed within a variable-size container.
+ * Delegates the rendering to the standard ModPreviewRenderer in COMPACT PreviewMode.
+ */
+@Environment(EnvType.CLIENT)
+public class VariableSizePreviewRenderer implements PreviewRenderer {
+
+    private static final PreviewRenderer DELEGATE = PreviewRenderer.getModRendererInstance();
+
+    private final Supplier<Integer> unlockedSlots;
+    private List<ItemStack> items;
+    private PreviewType previewType;
+    private int[] dims;
+
+    public VariableSizePreviewRenderer(Supplier<Integer> unlockedSlots) {
+        this.unlockedSlots = unlockedSlots;
+        this.items = List.of();
+        this.initDims();
+    }
+
+    @Override
+    public int getHeight() {
+        if (this.previewType != PreviewType.FULL) {
+            return DELEGATE.getHeight();
+        }
+        return 7 + this.dims[1] * 18 + 7;
+    }
+
+    @Override
+    public int getWidth() {
+        if (this.previewType != PreviewType.FULL) {
+            return DELEGATE.getHeight();
+        }
+        return 7 + this.dims[0] * 18 + 7;
+    }
+
+    @Override
+    public void setPreview(PreviewContext context, PreviewProvider provider) {
+        this.items = provider.getInventory(context);
+        this.initDims();
+        DELEGATE.setPreview(context, provider);
+    }
+
+    private void initDims() {
+        int size = this.unlockedSlots.get();
+        this.dims = VariableSizeContainerMenu.getRatio(size);
+        if (this.dims[0] > 9) {
+            this.dims[0] = 9;
+            this.dims[1] = (int) Math.ceil(size / 9f);
+        }
+    }
+
+    @Override
+    public void setPreviewType(PreviewType type) {
+        this.previewType = type;
+        DELEGATE.setPreviewType(type);
+    }
+
+    @Override
+    public void draw(int x, int y, GuiGraphics graphics, Font font, int mouseX, int mouseY) {
+        if (this.previewType != PreviewType.FULL) {
+            DELEGATE.draw(x, y, graphics, font, mouseX, mouseY);
+            return;
+        }
+        RenderSystem.enableDepthTest();
+        this.renderBackground(x, y, graphics);
+        this.renderSlots(x, y, graphics, font);
+        this.renderInnerTooltip(x, y, graphics, font, mouseX, mouseY);
+    }
+
+    private void renderBackground(int x, int y, GuiGraphics graphics) {
+        int w = this.dims[0] * 18;
+        int h = this.dims[1] * 18;
+        int rEdgeOffset = 7 + w;
+        int bEdgeOffset = 7 + h;
+
+        graphics.blit(ModTextures.VARIABLE_SIZE_CONTAINER_TEXTURE, x, y, 0, 0, rEdgeOffset, 7);
+        graphics.blit(ModTextures.VARIABLE_SIZE_CONTAINER_TEXTURE, x + rEdgeOffset, y, 7 + 9 * 18, 0, 7, 7);
+
+        graphics.blit(ModTextures.VARIABLE_SIZE_CONTAINER_TEXTURE, x, y + 7, 0, 7, rEdgeOffset, h);
+        graphics.blit(ModTextures.VARIABLE_SIZE_CONTAINER_TEXTURE, x + rEdgeOffset, y + 7, 7 + 9 * 18, 7, 7, h);
+
+        graphics.blit(ModTextures.VARIABLE_SIZE_CONTAINER_TEXTURE, x, y + bEdgeOffset, 0, 159, rEdgeOffset, 7);
+        graphics.blit(ModTextures.VARIABLE_SIZE_CONTAINER_TEXTURE, x + rEdgeOffset, y + bEdgeOffset, 7 + 9 * 18, 159,
+            7, 7);
+    }
+
+    private void renderSlots(int x, int y, GuiGraphics graphics, Font font) {
+        int dimx;
+        int slot = 0;
+        int size = this.unlockedSlots.get();
+        for (int h = 0; h < this.dims[1]; ++h) {
+            dimx = Math.min(this.dims[0], size);
+            int xp = 7 + (this.dims[0] * 18) / 2 - (dimx * 18) / 2;
+            for (int j = 0; j < dimx; ++j) {
+                int slotX = xp + x + j * 18;
+                int slotY = 7 + y + 18 * h;
+                graphics.blit(ModTextures.SLOT_TEXTURE, slotX, slotY, 0, 0, 18, 18, 18, 18);
+
+                if (slot < this.items.size()) {
+                    ItemStack stack = this.items.get(slot);
+                    graphics.renderFakeItem(stack, slotX + 1, slotY + 1);
+                    graphics.renderItemDecorations(font, stack, slotX + 1, slotY + 1);
+                }
+                ++slot;
+
+            }
+            size -= dims[0];
+        }
+    }
+
+    private ItemStack getStackAt(int x, int y) {
+        int slot = -1;
+
+        if (y >= 7) {
+            int slotY = (y - 7) / 18;
+            int size = this.unlockedSlots.get() - this.dims[0] * slotY;
+            int dimx = Math.min(this.dims[0], size);
+            int xp = 7 + (this.dims[0] * 18) / 2 - (dimx * 18) / 2;
+
+            if (x >= xp) {
+                int slotX = (x - xp) / 18;
+                if (slotX < dimx) {
+                    slot = slotX + slotY * this.dims[0];
+                }
+            }
+        }
+
+        if (slot >= 0 && slot < this.items.size()) {
+            return this.items.get(slot);
+        }
+        return ItemStack.EMPTY;
+    }
+
+    private void renderInnerTooltip(
+        int x, int y, GuiGraphics graphics, Font font, int mouseX,
+        int mouseY
+    ) {
+        ItemStack stack = this.getStackAt(mouseX - x, mouseY - y);
+
+        if (!stack.isEmpty()) {
+            graphics.renderTooltip(font, stack, mouseX, mouseY);
+        }
+    }
+
+}

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -82,6 +82,7 @@ dependencies {
     modCompileOnly("curse.maven:create-328085:4835191")
 
     modCompileOnly("org.embeddedt:embeddium-fabric-1.20.1:0.3.1-git.b3f920f+mc1.20.1")
+    modCompileOnly("com.misterpemodder:shulkerboxtooltip-fabric:${shulker_box_tooltip_version}") { transitive false }
 
 //    modImplementation("maven.modrinth:immediatelyfast:1.2.0+1.20.1") // Get latest version from releases
 

--- a/fabric/src/main/java/net/mehvahdjukaar/supplementaries/integration/fabric/ShulkerBoxTooltipCompatImpl.java
+++ b/fabric/src/main/java/net/mehvahdjukaar/supplementaries/integration/fabric/ShulkerBoxTooltipCompatImpl.java
@@ -1,0 +1,9 @@
+package net.mehvahdjukaar.supplementaries.integration.fabric;
+
+public class ShulkerBoxTooltipCompatImpl {
+
+    public static void registerPlugin() {
+        // On Fabric, SBT plugins are passively registered (see fabric.mod.json)
+    }
+
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -35,6 +35,9 @@
     ],
     "jade": [
       "net.mehvahdjukaar.supplementaries.integration.JadeCompat"
+    ],
+    "shulkerboxtooltip": [
+      "net.mehvahdjukaar.supplementaries.integration.ShulkerBoxTooltipCompat"
     ]
   },
   "mixins": [

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -190,6 +190,7 @@ dependencies {
     modCompileOnly("curse.maven:embeddium-908741:5566632")
     modCompileOnly("curse.maven:integrated-stronghold-815548:5178479")
     modCompileOnly("curse.maven:integrated-api-817709:5241489")
+    modCompileOnly("com.misterpemodder:shulkerboxtooltip-forge:${shulker_box_tooltip_version}") { transitive false }
 
     //modCompileOnly("maven.modrinth:immediatelyfast:1.2.0+1.20.1") // Get latest version from releases
 

--- a/forge/src/main/java/net/mehvahdjukaar/supplementaries/forge/SupplementariesForge.java
+++ b/forge/src/main/java/net/mehvahdjukaar/supplementaries/forge/SupplementariesForge.java
@@ -1,7 +1,6 @@
 package net.mehvahdjukaar.supplementaries.forge;
 
 import com.mojang.serialization.Codec;
-import com.mojang.serialization.MapCodec;
 import net.mehvahdjukaar.moonlight.api.platform.PlatHelper;
 import net.mehvahdjukaar.supplementaries.Supplementaries;
 import net.mehvahdjukaar.supplementaries.common.capabilities.CapabilityHandler;
@@ -9,6 +8,8 @@ import net.mehvahdjukaar.supplementaries.common.events.forge.ClientEventsForge;
 import net.mehvahdjukaar.supplementaries.common.events.forge.ServerEventsForge;
 import net.mehvahdjukaar.supplementaries.common.items.forge.ShulkerShellItem;
 import net.mehvahdjukaar.supplementaries.configs.CommonConfigs;
+import net.mehvahdjukaar.supplementaries.integration.CompatHandler;
+import net.mehvahdjukaar.supplementaries.integration.ShulkerBoxTooltipCompat;
 import net.mehvahdjukaar.supplementaries.reg.ClientRegistry;
 import net.mehvahdjukaar.supplementaries.reg.ModSetup;
 import net.minecraft.resources.ResourceLocation;
@@ -24,7 +25,6 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegisterEvent;
-import vectorwing.farmersdelight.FarmersDelight;
 
 import java.util.function.Supplier;
 
@@ -64,6 +64,11 @@ public class SupplementariesForge {
         ModSetup.asyncSetup();
         VillagerScareStuff.setup();
 
+        event.enqueueWork(() -> {
+            if (CompatHandler.SHULKER_BOX_TOOLTIP) {
+                ShulkerBoxTooltipCompat.registerPlugin();
+            }
+        });
     }
 
     @SubscribeEvent

--- a/forge/src/main/java/net/mehvahdjukaar/supplementaries/integration/forge/QuarkClientCompatImpl.java
+++ b/forge/src/main/java/net/mehvahdjukaar/supplementaries/integration/forge/QuarkClientCompatImpl.java
@@ -7,7 +7,9 @@ import net.mehvahdjukaar.supplementaries.api.IQuiverEntity;
 import net.mehvahdjukaar.supplementaries.common.block.tiles.SafeBlockTile;
 import net.mehvahdjukaar.supplementaries.common.items.*;
 import net.mehvahdjukaar.supplementaries.common.items.tooltip_components.InventoryTooltip;
+import net.mehvahdjukaar.supplementaries.integration.CompatHandler;
 import net.mehvahdjukaar.supplementaries.integration.QuarkClientCompat;
+import net.mehvahdjukaar.supplementaries.integration.ShulkerBoxTooltipCompat;
 import net.mehvahdjukaar.supplementaries.reg.ModRegistry;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
@@ -50,7 +52,9 @@ public class QuarkClientCompatImpl {
 
     public static void onItemTooltipEvent(RenderTooltipEvent.GatherComponents event) {
         ItemStack stack = event.getItemStack();
-        if (QuarkClientCompat.canRenderQuarkTooltip()) {
+        boolean quarkTooltip = QuarkClientCompat.canRenderQuarkTooltip();
+        boolean sbtTooltip = CompatHandler.SHULKER_BOX_TOOLTIP && ShulkerBoxTooltipCompat.hasPreviewProvider(stack);
+        if (quarkTooltip && !sbtTooltip) {
             Item item = stack.getItem();
             if (item instanceof SafeItem || item instanceof SackItem) {
                 CompoundTag cmp = ItemNBTHelper.getCompound(stack, "BlockEntityTag", false);

--- a/forge/src/main/java/net/mehvahdjukaar/supplementaries/integration/forge/ShulkerBoxTooltipCompatImpl.java
+++ b/forge/src/main/java/net/mehvahdjukaar/supplementaries/integration/forge/ShulkerBoxTooltipCompatImpl.java
@@ -1,0 +1,14 @@
+package net.mehvahdjukaar.supplementaries.integration.forge;
+
+import com.misterpemodder.shulkerboxtooltip.api.forge.ShulkerBoxTooltipPlugin;
+import net.mehvahdjukaar.supplementaries.integration.ShulkerBoxTooltipCompat;
+import net.minecraftforge.fml.ModLoadingContext;
+
+public class ShulkerBoxTooltipCompatImpl {
+
+    public static void registerPlugin() {
+        ModLoadingContext.get().registerExtensionPoint(ShulkerBoxTooltipPlugin.class,
+            () -> new ShulkerBoxTooltipPlugin(ShulkerBoxTooltipCompat::new));
+    }
+
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,7 @@ cca_version = 5.2.1
 port_lib_modules = accessors,base,networking,tags,config,tool_actions,loot,lazy_registration,recipe_book_categories
 port_lib_version = 2.3.4+1.20.1
 fabric_asm_version = v2.3
-
+shulker_box_tooltip_version = 4.0.4+1.20.1
 
 
 


### PR DESCRIPTION
Added ShulkerBoxTooltip plugin to enable previews for safes and sacks. The preview functionality overrides the one from Quark when both mods are present.
This targets Minecraft 1.20.1 for now, I will work on 1.21 if this PR is accepted.

## Safes
<img src="https://github.com/user-attachments/assets/507389c7-965c-41e3-beee-3fac08af3e74" width=500>

Added preview : only shows up when the player is allowed to open the safe.

## Sacks
<img src="https://github.com/user-attachments/assets/4a3f7ae6-1af9-4c8e-8cda-cd685d2d4819" width=500>

Added preview support with special handling of varying stack inventory size.
I suspect that the newly added rendering code in `VariableSizePreviewRenderer` will not survive a port to 1.20.6. Don't hesitate to ask me if you want support for that version as well.

**Orignal issue:** https://github.com/MisterPeModder/ShulkerBoxTooltip/issues/150
