### PR TITLE
Add ShulkerBoxTooltip Compatibility (1.21.1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -208,6 +208,7 @@ allprojects {
         maven { url = "https://maven.tterrag.com/" } // Flywheel
         maven { url = "https://mvn.devos.one/snapshots/" } // Registrate, Porting Lib, Forge Tags, Milk Lib
         maven { url = "https://mvn.devos.one/releases/" }
+        maven { url = "https://maven.misterpemodder.com/libs-release/" } // ShulkerBoxTooltip
 
     }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     modCompileOnly("curse.maven:buzzier-bees-355458:4776328")
     modCompileOnly("maven.modrinth:frozenlib:1.7.4-mc1.20.1")
     modCompileOnly("curse.maven:amendments-896746:5692774")
+    modCompileOnly("com.misterpemodder:shulkerboxtooltip-common:${shulker_box_tooltip_version}") { transitive false }
 
 }
 

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/block/tiles/SafeBlockTile.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/block/tiles/SafeBlockTile.java
@@ -123,7 +123,9 @@ public class SafeBlockTile extends OpeneableContainerBlockEntity implements IOwn
             }
         } else {
             KeyStatus status = getKeyInInventoryStatus(player);
-            status.sendMessage(player, feedbackMessage ? "safe" : null);
+            if (feedbackMessage) {
+                status.sendMessage(player, feedbackMessage ? "safe" : null);
+            }
             return status.isCorrect();
         }
         return true;

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/items/SackItem.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/items/SackItem.java
@@ -7,6 +7,7 @@ import net.mehvahdjukaar.supplementaries.configs.CommonConfigs;
 import net.mehvahdjukaar.supplementaries.integration.CompatHandler;
 import net.mehvahdjukaar.supplementaries.integration.QuarkClientCompat;
 import net.mehvahdjukaar.supplementaries.integration.QuarkCompat;
+import net.mehvahdjukaar.supplementaries.integration.ShulkerBoxTooltipCompat;
 import net.mehvahdjukaar.supplementaries.reg.ModRegistry;
 import net.mehvahdjukaar.supplementaries.reg.ModTags;
 import net.minecraft.core.component.DataComponents;
@@ -60,7 +61,9 @@ public class SackItem extends BlockItem {
     @Override
     public void appendHoverText(ItemStack stack, TooltipContext context, List<Component> tooltipComponents, TooltipFlag tooltipFlag) {
         super.appendHoverText(stack, context, tooltipComponents, tooltipFlag);
-        if (!CompatHandler.QUARK || !QuarkClientCompat.canRenderQuarkTooltip()) {
+        boolean quarkTooltips = CompatHandler.QUARK && QuarkClientCompat.canRenderQuarkTooltip();
+        boolean sbtTooltips = CompatHandler.SHULKER_BOX_TOOLTIP && ShulkerBoxTooltipCompat.isPreviewAvailable(stack);
+        if (!quarkTooltips && !sbtTooltips) {
             ItemsUtil.addShulkerLikeTooltips(stack, tooltipComponents);
         }
     }
@@ -94,7 +97,9 @@ public class SackItem extends BlockItem {
 
     @Override
     public Optional<TooltipComponent> getTooltipImage(ItemStack pStack) {
-        if (CompatHandler.QUARK && QuarkClientCompat.canRenderQuarkTooltip()) {
+        boolean quarkTooltips = CompatHandler.QUARK && QuarkClientCompat.canRenderQuarkTooltip();
+        boolean sbtTooltips = CompatHandler.SHULKER_BOX_TOOLTIP && ShulkerBoxTooltipCompat.isPreviewAvailable(pStack);
+        if (quarkTooltips && !sbtTooltips) {
             if (!pStack.has(DataComponents.CONTAINER_LOOT)) {
                 var container = pStack.get(DataComponents.CONTAINER);
                 return Optional.of(new InventoryViewTooltip(container, CommonConfigs.Functional.SACK_SLOTS.get()));

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/items/SackItem.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/items/SackItem.java
@@ -62,7 +62,7 @@ public class SackItem extends BlockItem {
     public void appendHoverText(ItemStack stack, TooltipContext context, List<Component> tooltipComponents, TooltipFlag tooltipFlag) {
         super.appendHoverText(stack, context, tooltipComponents, tooltipFlag);
         boolean quarkTooltips = CompatHandler.QUARK && QuarkClientCompat.canRenderQuarkTooltip();
-        boolean sbtTooltips = CompatHandler.SHULKER_BOX_TOOLTIP && ShulkerBoxTooltipCompat.isPreviewAvailable(stack);
+        boolean sbtTooltips = CompatHandler.SHULKER_BOX_TOOLTIP && ShulkerBoxTooltipCompat.hasPreviewProvider(stack);
         if (!quarkTooltips && !sbtTooltips) {
             ItemsUtil.addShulkerLikeTooltips(stack, tooltipComponents);
         }
@@ -98,7 +98,7 @@ public class SackItem extends BlockItem {
     @Override
     public Optional<TooltipComponent> getTooltipImage(ItemStack pStack) {
         boolean quarkTooltips = CompatHandler.QUARK && QuarkClientCompat.canRenderQuarkTooltip();
-        boolean sbtTooltips = CompatHandler.SHULKER_BOX_TOOLTIP && ShulkerBoxTooltipCompat.isPreviewAvailable(pStack);
+        boolean sbtTooltips = CompatHandler.SHULKER_BOX_TOOLTIP && ShulkerBoxTooltipCompat.hasPreviewProvider(pStack);
         if (quarkTooltips && !sbtTooltips) {
             if (!pStack.has(DataComponents.CONTAINER_LOOT)) {
                 var container = pStack.get(DataComponents.CONTAINER);

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/items/SafeItem.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/items/SafeItem.java
@@ -1,12 +1,12 @@
 package net.mehvahdjukaar.supplementaries.common.items;
 
-
 import net.mehvahdjukaar.supplementaries.common.items.tooltip_components.InventoryViewTooltip;
 import net.mehvahdjukaar.supplementaries.common.utils.ItemsUtil;
 import net.mehvahdjukaar.supplementaries.integration.CompatHandler;
 import net.mehvahdjukaar.supplementaries.integration.QuarkClientCompat;
 import net.mehvahdjukaar.supplementaries.integration.QuarkCompat;
 import net.minecraft.core.component.DataComponents;
+import net.mehvahdjukaar.supplementaries.integration.ShulkerBoxTooltipCompat;
 import net.minecraft.world.entity.SlotAccess;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.ClickAction;
@@ -43,7 +43,9 @@ public class SafeItem extends BlockItem {
     @Override
     @SuppressWarnings("ConstantConditions")
     public Optional<TooltipComponent> getTooltipImage(ItemStack pStack) {
-        if (CompatHandler.QUARK && QuarkClientCompat.canRenderBlackboardTooltip()) {
+        boolean quarkTooltip = CompatHandler.QUARK && QuarkClientCompat.canRenderBlackboardTooltip();
+        boolean sbtTooltip = CompatHandler.SHULKER_BOX_TOOLTIP && ShulkerBoxTooltipCompat.hasPreviewProvider(pStack);
+        if (quarkTooltip && !sbtTooltip) {
             var container = pStack.get(DataComponents.CONTAINER);
             if (container != null && !pStack.has(DataComponents.CONTAINER_LOOT)) {
                 return Optional.of(new InventoryViewTooltip(container, 27));

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/items/components/SafeOwner.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/items/components/SafeOwner.java
@@ -36,8 +36,8 @@ public final class SafeOwner implements TooltipProvider {
 
     public static final StreamCodec<RegistryFriendlyByteBuf, SafeOwner> STREAM_CODEC = StreamCodec.composite(
             ByteBufCodecs.optional(UUIDUtil.STREAM_CODEC), s -> Optional.ofNullable(s.owner),
-            ByteBufCodecs.optional(ByteBufCodecs.STRING_UTF8), s -> Optional.ofNullable(s.password),
             ByteBufCodecs.optional(ByteBufCodecs.STRING_UTF8), s -> Optional.ofNullable(s.ownerName),
+            ByteBufCodecs.optional(ByteBufCodecs.STRING_UTF8), s -> Optional.ofNullable(s.password),
             SafeOwner::new
     );
 

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/CompatHandler.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/CompatHandler.java
@@ -81,6 +81,7 @@ public class CompatHandler {
     public static final boolean FARMERS_RESPRITE = isLoaded("farmersrespite");
     public static final boolean ARCHITECTS_PALETTE = isLoaded("architects_palette");
     public static final boolean OPTIFINE;
+    public static final boolean SHULKER_BOX_TOOLTIP = isLoaded("shulkerboxtooltip");
 
     static {
         boolean of = false;

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/ShulkerBoxTooltipCompat.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/ShulkerBoxTooltipCompat.java
@@ -1,8 +1,6 @@
 package net.mehvahdjukaar.supplementaries.integration;
 
-import com.misterpemodder.shulkerboxtooltip.api.PreviewContext;
 import com.misterpemodder.shulkerboxtooltip.api.ShulkerBoxTooltipApi;
-import com.misterpemodder.shulkerboxtooltip.api.provider.PreviewProvider;
 import com.misterpemodder.shulkerboxtooltip.api.provider.PreviewProviderRegistry;
 import dev.architectury.injectables.annotations.ExpectPlatform;
 import net.mehvahdjukaar.supplementaries.Supplementaries;
@@ -21,9 +19,8 @@ public class ShulkerBoxTooltipCompat implements ShulkerBoxTooltipApi {
             ModRegistry.SACK_ITEM.get());
     }
 
-    public static boolean isPreviewAvailable(ItemStack stack) {
-        PreviewProvider provider = ShulkerBoxTooltipApi.getPreviewProviderForStack(stack);
-        return provider != null && provider.shouldDisplay(PreviewContext.builder(stack).build());
+    public static boolean hasPreviewProvider(ItemStack stack) {
+        return ShulkerBoxTooltipApi.getPreviewProviderForStack(stack) != null;
     }
 
     @ExpectPlatform

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/ShulkerBoxTooltipCompat.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/ShulkerBoxTooltipCompat.java
@@ -1,0 +1,34 @@
+package net.mehvahdjukaar.supplementaries.integration;
+
+import com.misterpemodder.shulkerboxtooltip.api.PreviewContext;
+import com.misterpemodder.shulkerboxtooltip.api.ShulkerBoxTooltipApi;
+import com.misterpemodder.shulkerboxtooltip.api.provider.PreviewProvider;
+import com.misterpemodder.shulkerboxtooltip.api.provider.PreviewProviderRegistry;
+import dev.architectury.injectables.annotations.ExpectPlatform;
+import net.mehvahdjukaar.supplementaries.Supplementaries;
+import net.mehvahdjukaar.supplementaries.integration.shulkerboxtooltip.SackPreviewProvider;
+import net.mehvahdjukaar.supplementaries.integration.shulkerboxtooltip.SafePreviewProvider;
+import net.mehvahdjukaar.supplementaries.reg.ModRegistry;
+import net.minecraft.world.item.ItemStack;
+
+public class ShulkerBoxTooltipCompat implements ShulkerBoxTooltipApi {
+
+    @Override
+    public void registerProviders(PreviewProviderRegistry registry) {
+        registry.register(Supplementaries.res("safe"), new SafePreviewProvider(),
+            ModRegistry.SAFE_ITEM.get());
+        registry.register(Supplementaries.res("sack"), new SackPreviewProvider(),
+            ModRegistry.SACK_ITEM.get());
+    }
+
+    public static boolean isPreviewAvailable(ItemStack stack) {
+        PreviewProvider provider = ShulkerBoxTooltipApi.getPreviewProviderForStack(stack);
+        return provider != null && provider.shouldDisplay(PreviewContext.builder(stack).build());
+    }
+
+    @ExpectPlatform
+    public static void registerPlugin() {
+        throw new AssertionError();
+    }
+
+}

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/SackPreviewProvider.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/SackPreviewProvider.java
@@ -2,9 +2,15 @@ package net.mehvahdjukaar.supplementaries.integration.shulkerboxtooltip;
 
 import com.misterpemodder.shulkerboxtooltip.api.PreviewContext;
 import com.misterpemodder.shulkerboxtooltip.api.provider.BlockEntityPreviewProvider;
+import com.misterpemodder.shulkerboxtooltip.api.renderer.PreviewRenderer;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.mehvahdjukaar.supplementaries.common.block.tiles.SackBlockTile;
 
 public final class SackPreviewProvider extends BlockEntityPreviewProvider {
+
+    @Environment(EnvType.CLIENT)
+    private static final PreviewRenderer RENDERER = new VariableSizePreviewRenderer(SackBlockTile::getUnlockedSlots);
 
     public SackPreviewProvider() {
         super(SackBlockTile.getUnlockedSlots(), true);
@@ -13,6 +19,12 @@ public final class SackPreviewProvider extends BlockEntityPreviewProvider {
     @Override
     public int getInventoryMaxSize(PreviewContext context) {
         return SackBlockTile.getUnlockedSlots();
+    }
+
+    @Override
+    @Environment(EnvType.CLIENT)
+    public PreviewRenderer getRenderer() {
+        return RENDERER;
     }
 
 }

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/SackPreviewProvider.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/SackPreviewProvider.java
@@ -1,0 +1,18 @@
+package net.mehvahdjukaar.supplementaries.integration.shulkerboxtooltip;
+
+import com.misterpemodder.shulkerboxtooltip.api.PreviewContext;
+import com.misterpemodder.shulkerboxtooltip.api.provider.BlockEntityPreviewProvider;
+import net.mehvahdjukaar.supplementaries.common.block.tiles.SackBlockTile;
+
+public final class SackPreviewProvider extends BlockEntityPreviewProvider {
+
+    public SackPreviewProvider() {
+        super(SackBlockTile.getUnlockedSlots(), true);
+    }
+
+    @Override
+    public int getInventoryMaxSize(PreviewContext context) {
+        return SackBlockTile.getUnlockedSlots();
+    }
+
+}

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/SafePreviewProvider.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/SafePreviewProvider.java
@@ -1,11 +1,36 @@
 package net.mehvahdjukaar.supplementaries.integration.shulkerboxtooltip;
 
+import com.google.common.base.Suppliers;
+import com.misterpemodder.shulkerboxtooltip.api.PreviewContext;
 import com.misterpemodder.shulkerboxtooltip.api.provider.BlockEntityPreviewProvider;
+import net.mehvahdjukaar.supplementaries.common.block.tiles.SafeBlockTile;
+import net.mehvahdjukaar.supplementaries.common.items.SafeItem;
+import net.mehvahdjukaar.supplementaries.reg.ModRegistry;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.function.Supplier;
 
 public final class SafePreviewProvider extends BlockEntityPreviewProvider {
 
+    private static final Supplier<SafeBlockTile> DUMMY_SAFE_TILE = Suppliers.memoize(() -> new SafeBlockTile(BlockPos.ZERO,
+        ModRegistry.SAFE.get().defaultBlockState()));
+
     public SafePreviewProvider() {
         super(27, true);
+    }
+
+    @Override
+    public boolean shouldDisplay(PreviewContext context) {
+        if (!super.shouldDisplay(context)) {
+            return false;
+        }
+        ItemStack stack = context.stack();
+        if (stack.getItem() instanceof SafeItem) {
+            DUMMY_SAFE_TILE.get().applyComponentsFromItemStack(stack);
+            return DUMMY_SAFE_TILE.get().canPlayerOpen(context.owner(), false);
+        }
+        return false;
     }
 
 }

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/SafePreviewProvider.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/SafePreviewProvider.java
@@ -1,0 +1,11 @@
+package net.mehvahdjukaar.supplementaries.integration.shulkerboxtooltip;
+
+import com.misterpemodder.shulkerboxtooltip.api.provider.BlockEntityPreviewProvider;
+
+public final class SafePreviewProvider extends BlockEntityPreviewProvider {
+
+    public SafePreviewProvider() {
+        super(27, true);
+    }
+
+}

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/VariableSizePreviewRenderer.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/VariableSizePreviewRenderer.java
@@ -11,6 +11,7 @@ import net.mehvahdjukaar.supplementaries.common.inventories.VariableSizeContaine
 import net.mehvahdjukaar.supplementaries.reg.ModTextures;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.world.item.ItemStack;
 
 import java.util.List;
@@ -82,7 +83,7 @@ public class VariableSizePreviewRenderer implements PreviewRenderer {
         }
         RenderSystem.enableDepthTest();
         this.renderBackground(x, y, graphics);
-        this.renderSlots(x, y, graphics, font);
+        this.renderSlots(x, y, graphics, font, mouseX, mouseY);
         this.renderInnerTooltip(x, y, graphics, font, mouseX, mouseY);
     }
 
@@ -103,7 +104,7 @@ public class VariableSizePreviewRenderer implements PreviewRenderer {
             7, 7);
     }
 
-    private void renderSlots(int x, int y, GuiGraphics graphics, Font font) {
+    private void renderSlots(int x, int y, GuiGraphics graphics, Font font, int mouseX, int mouseY) {
         int dimx;
         int slot = 0;
         int size = this.unlockedSlots.get();
@@ -114,6 +115,10 @@ public class VariableSizePreviewRenderer implements PreviewRenderer {
                 int slotX = xp + x + j * 18;
                 int slotY = 7 + y + 18 * h;
                 graphics.blitSprite(ModTextures.SLOT_SPRITE, slotX, slotY, 18, 18);
+
+                if (mouseX >= slotX && mouseX < slotX + 18 && mouseY >= slotY && mouseY < slotY + 18) {
+                    AbstractContainerScreen.renderSlotHighlight(graphics, slotX + 1, slotY + 1, 0);
+                }
 
                 if (slot < this.items.size()) {
                     ItemStack stack = this.items.get(slot);

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/VariableSizePreviewRenderer.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/VariableSizePreviewRenderer.java
@@ -113,7 +113,7 @@ public class VariableSizePreviewRenderer implements PreviewRenderer {
             for (int j = 0; j < dimx; ++j) {
                 int slotX = xp + x + j * 18;
                 int slotY = 7 + y + 18 * h;
-                graphics.blit(ModTextures.SLOT_TEXTURE, slotX, slotY, 0, 0, 18, 18, 18, 18);
+                graphics.blitSprite(ModTextures.SLOT_SPRITE, slotX, slotY, 18, 18);
 
                 if (slot < this.items.size()) {
                     ItemStack stack = this.items.get(slot);

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/VariableSizePreviewRenderer.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/integration/shulkerboxtooltip/VariableSizePreviewRenderer.java
@@ -1,0 +1,164 @@
+package net.mehvahdjukaar.supplementaries.integration.shulkerboxtooltip;
+
+import com.misterpemodder.shulkerboxtooltip.api.PreviewContext;
+import com.misterpemodder.shulkerboxtooltip.api.PreviewType;
+import com.misterpemodder.shulkerboxtooltip.api.provider.PreviewProvider;
+import com.misterpemodder.shulkerboxtooltip.api.renderer.PreviewRenderer;
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.mehvahdjukaar.supplementaries.common.inventories.VariableSizeContainerMenu;
+import net.mehvahdjukaar.supplementaries.reg.ModTextures;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * A PreviewRenderer that mimics the way slots are placed within a variable-size container.
+ * Delegates the rendering to the standard ModPreviewRenderer in COMPACT PreviewMode.
+ */
+@Environment(EnvType.CLIENT)
+public class VariableSizePreviewRenderer implements PreviewRenderer {
+
+    private static final PreviewRenderer DELEGATE = PreviewRenderer.getModRendererInstance();
+
+    private final Supplier<Integer> unlockedSlots;
+    private List<ItemStack> items;
+    private PreviewType previewType;
+    private int[] dims;
+
+    public VariableSizePreviewRenderer(Supplier<Integer> unlockedSlots) {
+        this.unlockedSlots = unlockedSlots;
+        this.items = List.of();
+        this.initDims();
+    }
+
+    @Override
+    public int getHeight() {
+        if (this.previewType != PreviewType.FULL) {
+            return DELEGATE.getHeight();
+        }
+        return 7 + this.dims[1] * 18 + 7;
+    }
+
+    @Override
+    public int getWidth() {
+        if (this.previewType != PreviewType.FULL) {
+            return DELEGATE.getHeight();
+        }
+        return 7 + this.dims[0] * 18 + 7;
+    }
+
+    @Override
+    public void setPreview(PreviewContext context, PreviewProvider provider) {
+        this.items = provider.getInventory(context);
+        this.initDims();
+        DELEGATE.setPreview(context, provider);
+    }
+
+    private void initDims() {
+        int size = this.unlockedSlots.get();
+        this.dims = VariableSizeContainerMenu.getRatio(size);
+        if (this.dims[0] > 9) {
+            this.dims[0] = 9;
+            this.dims[1] = (int) Math.ceil(size / 9f);
+        }
+    }
+
+    @Override
+    public void setPreviewType(PreviewType type) {
+        this.previewType = type;
+        DELEGATE.setPreviewType(type);
+    }
+
+    @Override
+    public void draw(int x, int y, GuiGraphics graphics, Font font, int mouseX, int mouseY) {
+        if (this.previewType != PreviewType.FULL) {
+            DELEGATE.draw(x, y, graphics, font, mouseX, mouseY);
+            return;
+        }
+        RenderSystem.enableDepthTest();
+        this.renderBackground(x, y, graphics);
+        this.renderSlots(x, y, graphics, font);
+        this.renderInnerTooltip(x, y, graphics, font, mouseX, mouseY);
+    }
+
+    private void renderBackground(int x, int y, GuiGraphics graphics) {
+        int w = this.dims[0] * 18;
+        int h = this.dims[1] * 18;
+        int rEdgeOffset = 7 + w;
+        int bEdgeOffset = 7 + h;
+
+        graphics.blit(ModTextures.VARIABLE_SIZE_CONTAINER_TEXTURE, x, y, 0, 0, rEdgeOffset, 7);
+        graphics.blit(ModTextures.VARIABLE_SIZE_CONTAINER_TEXTURE, x + rEdgeOffset, y, 7 + 9 * 18, 0, 7, 7);
+
+        graphics.blit(ModTextures.VARIABLE_SIZE_CONTAINER_TEXTURE, x, y + 7, 0, 7, rEdgeOffset, h);
+        graphics.blit(ModTextures.VARIABLE_SIZE_CONTAINER_TEXTURE, x + rEdgeOffset, y + 7, 7 + 9 * 18, 7, 7, h);
+
+        graphics.blit(ModTextures.VARIABLE_SIZE_CONTAINER_TEXTURE, x, y + bEdgeOffset, 0, 159, rEdgeOffset, 7);
+        graphics.blit(ModTextures.VARIABLE_SIZE_CONTAINER_TEXTURE, x + rEdgeOffset, y + bEdgeOffset, 7 + 9 * 18, 159,
+            7, 7);
+    }
+
+    private void renderSlots(int x, int y, GuiGraphics graphics, Font font) {
+        int dimx;
+        int slot = 0;
+        int size = this.unlockedSlots.get();
+        for (int h = 0; h < this.dims[1]; ++h) {
+            dimx = Math.min(this.dims[0], size);
+            int xp = 7 + (this.dims[0] * 18) / 2 - (dimx * 18) / 2;
+            for (int j = 0; j < dimx; ++j) {
+                int slotX = xp + x + j * 18;
+                int slotY = 7 + y + 18 * h;
+                graphics.blit(ModTextures.SLOT_TEXTURE, slotX, slotY, 0, 0, 18, 18, 18, 18);
+
+                if (slot < this.items.size()) {
+                    ItemStack stack = this.items.get(slot);
+                    graphics.renderFakeItem(stack, slotX + 1, slotY + 1);
+                    graphics.renderItemDecorations(font, stack, slotX + 1, slotY + 1);
+                }
+                ++slot;
+
+            }
+            size -= dims[0];
+        }
+    }
+
+    private ItemStack getStackAt(int x, int y) {
+        int slot = -1;
+
+        if (y >= 7) {
+            int slotY = (y - 7) / 18;
+            int size = this.unlockedSlots.get() - this.dims[0] * slotY;
+            int dimx = Math.min(this.dims[0], size);
+            int xp = 7 + (this.dims[0] * 18) / 2 - (dimx * 18) / 2;
+
+            if (x >= xp) {
+                int slotX = (x - xp) / 18;
+                if (slotX < dimx) {
+                    slot = slotX + slotY * this.dims[0];
+                }
+            }
+        }
+
+        if (slot >= 0 && slot < this.items.size()) {
+            return this.items.get(slot);
+        }
+        return ItemStack.EMPTY;
+    }
+
+    private void renderInnerTooltip(
+        int x, int y, GuiGraphics graphics, Font font, int mouseX,
+        int mouseY
+    ) {
+        ItemStack stack = this.getStackAt(mouseX - x, mouseY - y);
+
+        if (!stack.isEmpty()) {
+            graphics.renderTooltip(font, stack, mouseX, mouseY);
+        }
+    }
+
+}

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -87,6 +87,7 @@ dependencies {
 
     modCompileOnly("org.embeddedt:embeddium-fabric-1.20.1:0.3.1-git.b3f920f+mc1.20.1")
     modImplementation("maven.modrinth:flashback:0.11.0") // Get latest version from releases
+    modCompileOnly("com.misterpemodder:shulkerboxtooltip-fabric:${shulker_box_tooltip_version}") { transitive false }
 
 //    modImplementation("maven.modrinth:immediatelyfast:1.2.0+1.20.1") // Get latest version from releases
 

--- a/fabric/src/main/java/net/mehvahdjukaar/supplementaries/integration/fabric/ShulkerBoxTooltipCompatImpl.java
+++ b/fabric/src/main/java/net/mehvahdjukaar/supplementaries/integration/fabric/ShulkerBoxTooltipCompatImpl.java
@@ -1,0 +1,9 @@
+package net.mehvahdjukaar.supplementaries.integration.fabric;
+
+public class ShulkerBoxTooltipCompatImpl {
+
+    public static void registerPlugin() {
+        // On Fabric, SBT plugins are passively registered (see fabric.mod.json)
+    }
+
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -35,6 +35,9 @@
     ],
     "jade": [
       "net.mehvahdjukaar.supplementaries.integration.JadeCompat"
+    ],
+    "shulkerboxtooltip": [
+      "net.mehvahdjukaar.supplementaries.integration.ShulkerBoxTooltipCompat"
     ]
   },
   "mixins": [

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,7 +55,7 @@ emi_version = 0.7.3
 trinkets_version = 3.10.0
 suppsquared_version = 1.20-1.1.5
 cca_version = 5.2.1
-
+shulker_box_tooltip_version = 5.1.3+1.21.1
 
 
 

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -177,6 +177,7 @@ dependencies {
 
     modCompileOnly("curse.maven:integrated-stronghold-815548:5178479")
     modCompileOnly("curse.maven:integrated-api-817709:5241489")
+    modCompileOnly("com.misterpemodder:shulkerboxtooltip-neoforge:${shulker_box_tooltip_version}") { transitive false }
 
     //modCompileOnly("maven.modrinth:immediatelyfast:1.2.0+1.20.1") // Get latest version from releases
 

--- a/neoforge/src/main/java/net/mehvahdjukaar/supplementaries/integration/neoforge/QuarkClientCompatImpl.java
+++ b/neoforge/src/main/java/net/mehvahdjukaar/supplementaries/integration/neoforge/QuarkClientCompatImpl.java
@@ -8,6 +8,7 @@ import net.mehvahdjukaar.supplementaries.common.block.tiles.SafeBlockTile;
 import net.mehvahdjukaar.supplementaries.common.items.*;
 import net.mehvahdjukaar.supplementaries.common.items.tooltip_components.InventoryViewTooltip;
 import net.mehvahdjukaar.supplementaries.integration.QuarkClientCompat;
+import net.mehvahdjukaar.supplementaries.integration.ShulkerBoxTooltipCompat;
 import net.mehvahdjukaar.supplementaries.reg.ModRegistry;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
@@ -51,7 +52,9 @@ public class QuarkClientCompatImpl {
 
     public static void onItemTooltipEvent(RenderTooltipEvent.GatherComponents event) {
         ItemStack stack = event.getItemStack();
-        if (QuarkClientCompat.canRenderQuarkTooltip()) {
+        boolean quarkTooltip = QuarkClientCompat.canRenderQuarkTooltip();
+        boolean sbtTooltip = CompatHandler.SHULKER_BOX_TOOLTIP && ShulkerBoxTooltipCompat.hasPreviewProvider(stack);
+        if (quarkTooltip && !sbtTooltip) {
             Item item = stack.getItem();
             if (item instanceof SafeItem || item instanceof SackItem) {
                 CompoundTag cmp = ItemNBTHelper.getCompound(stack, "BlockEntityTag", false);

--- a/neoforge/src/main/java/net/mehvahdjukaar/supplementaries/integration/neoforge/ShulkerBoxTooltipCompatImpl.java
+++ b/neoforge/src/main/java/net/mehvahdjukaar/supplementaries/integration/neoforge/ShulkerBoxTooltipCompatImpl.java
@@ -1,0 +1,14 @@
+package net.mehvahdjukaar.supplementaries.integration.neoforge;
+
+import com.misterpemodder.shulkerboxtooltip.api.neoforge.ShulkerBoxTooltipPlugin;
+import net.mehvahdjukaar.supplementaries.integration.ShulkerBoxTooltipCompat;
+import net.neoforged.fml.ModLoadingContext;
+
+public class ShulkerBoxTooltipCompatImpl {
+
+    public static void registerPlugin() {
+        ModLoadingContext.get().registerExtensionPoint(ShulkerBoxTooltipPlugin.class,
+            () -> new ShulkerBoxTooltipPlugin(ShulkerBoxTooltipCompat::new));
+    }
+
+}

--- a/neoforge/src/main/java/net/mehvahdjukaar/supplementaries/neoforge/SupplementariesForge.java
+++ b/neoforge/src/main/java/net/mehvahdjukaar/supplementaries/neoforge/SupplementariesForge.java
@@ -6,6 +6,8 @@ import net.mehvahdjukaar.moonlight.api.platform.RegHelper;
 import net.mehvahdjukaar.supplementaries.Supplementaries;
 import net.mehvahdjukaar.supplementaries.common.events.neoforge.ClientEventsForge;
 import net.mehvahdjukaar.supplementaries.common.events.neoforge.ServerEventsForge;
+import net.mehvahdjukaar.supplementaries.integration.CompatHandler;
+import net.mehvahdjukaar.supplementaries.integration.ShulkerBoxTooltipCompat;
 import net.mehvahdjukaar.supplementaries.reg.ClientRegistry;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -55,6 +57,12 @@ public class SupplementariesForge {
     @SubscribeEvent
     public void setup(FMLCommonSetupEvent event) {
         VillagerScareStuff.setup();
+
+        event.enqueueWork(() -> {
+            if (CompatHandler.SHULKER_BOX_TOOLTIP) {
+                ShulkerBoxTooltipCompat.registerPlugin();
+            }
+        });
     }
 
     public static final ItemAbility SOAP_CLEAN = ItemAbility.get("soap_clean");


### PR DESCRIPTION
Like PR #1339, this adds ShulkerBoxTooltip compatibility for the 1.21 branch.

This fixes a bug in the serialization of the SafeOwner component where the owner name and password would get swapped.