### PR TITLE
Improve display link blackboard encoding

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/block/tiles/BlackboardBlockTile.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/block/tiles/BlackboardBlockTile.java
@@ -127,9 +127,44 @@ public class BlackboardBlockTile extends BlockEntity implements IOwnerProtected,
         return bytes;
     }
 
-    //string length = 16*4 = 64
+    //string length = 16*4+64 = 128
     public static String packPixelsToString(long[] packed) {
         StringBuilder builder = new StringBuilder();
+        for (var l : packed) {
+            char c = 0;
+            for (int k = 0; k < 4; k++) {
+				byte h = 0;
+				for(int j = 0; j < 4; j++) {
+					h = (byte)(h | ((l >> (j + (4 * k))) & 1));
+				}
+                c = (char) (c | (h << k));
+            }
+            char c1 = 0;
+            for (int k = 0; k < 4; k++) {
+                byte h = 0;
+				for(int j = 0; j < 4; j++) {
+					h = (byte)(h | ((l >> (j + 16 + (4 * k))) & 1));
+				}
+                c1 = (char) (c1 | (h << k));
+            }
+            char c2 = 0;
+            for (int k = 0; k < 4; k++) {
+                byte h = 0;
+				for(int j = 0; j < 4; j++) {
+					h = (byte)(h | ((l >> (j + 32 + (4 * k))) & 1));
+				}
+                c2 = (char) (c2 | (h << k));
+            }
+            char c3 = 0;
+            for (int k = 0; k < 4; k++) {
+                byte h = 0;
+				for(int j = 0; j < 4; j++) {
+					h = (byte)(h | ((l >> (j + 48 + (4 * k))) & 1));
+				}
+                c3 = (char) (c3 | (h << k));
+            }
+            builder.append(c).append(c1).append(c2).append(c3);
+        }
         for (var l : packed) {
             char a = (char) (l & Character.MAX_VALUE);
             char b = (char) (l >> 16 & Character.MAX_VALUE);
@@ -141,11 +176,14 @@ public class BlackboardBlockTile extends BlockEntity implements IOwnerProtected,
     }
 
     public static long[] unpackPixelsFromString(String packed) {
-        long[] unpacked = new long[16];
-        var chars = packed.toCharArray();
+        long[] unpacked = unpackPixelsFromStringWhiteOnly(packed);
+		if (packed.length() <= 64)
+			return unpacked;
+        var chars = packed.substring(64).toCharArray();
         int j = 0;
-        for (int i = 0; i + 3 < chars.length; i += 4) {
-            unpacked[j] = (long) chars[i + 3] << 48 | (long) chars[i + 2] << 32 | (long) chars[i + 1] << 16 | chars[i];
+        for (int i = 0; i + 3 < chars.length && j < 16; i += 4) {
+            unpacked[j] = (unpacked[j] << 3) | (unpacked[j] << 2) | (unpacked[j] << 1);
+			unpacked[j] = unpacked[j] & ((long) chars[i + 3] << 48 | (long) chars[i + 2] << 32 | (long) chars[i + 1] << 16 | chars[i]);
             j++;
         }
         return unpacked;
@@ -155,7 +193,7 @@ public class BlackboardBlockTile extends BlockEntity implements IOwnerProtected,
         long[] unpacked = new long[16];
         var chars = packed.toCharArray();
         int j = 0;
-        for (int i = 0; i + 3 < chars.length; i += 4) {
+        for (int i = 0; i + 3 < chars.length && j < 16; i += 4) {
             long l = 0;
             char c = chars[i];
             for (int k = 0; k < 4; k++) {

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/block/tiles/BlackboardBlockTile.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/block/tiles/BlackboardBlockTile.java
@@ -133,34 +133,34 @@ public class BlackboardBlockTile extends BlockEntity implements IOwnerProtected,
         for (var l : packed) {
             char c = 0;
             for (int k = 0; k < 4; k++) {
-				byte h = 0;
-				for(int j = 0; j < 4; j++) {
-					h = (byte)(h | ((l >> (j + (4 * k))) & 1));
-				}
+                byte h = 0;
+                for(int j = 0; j < 4; j++) {
+                    h = (byte)(h | ((l >> (j + (4 * k))) & 1));
+                }
                 c = (char) (c | (h << k));
             }
             char c1 = 0;
             for (int k = 0; k < 4; k++) {
                 byte h = 0;
-				for(int j = 0; j < 4; j++) {
-					h = (byte)(h | ((l >> (j + 16 + (4 * k))) & 1));
-				}
+                for(int j = 0; j < 4; j++) {
+                    h = (byte)(h | ((l >> (j + 16 + (4 * k))) & 1));
+                }
                 c1 = (char) (c1 | (h << k));
             }
             char c2 = 0;
             for (int k = 0; k < 4; k++) {
                 byte h = 0;
-				for(int j = 0; j < 4; j++) {
-					h = (byte)(h | ((l >> (j + 32 + (4 * k))) & 1));
-				}
+                for(int j = 0; j < 4; j++) {
+                    h = (byte)(h | ((l >> (j + 32 + (4 * k))) & 1));
+                }
                 c2 = (char) (c2 | (h << k));
             }
             char c3 = 0;
             for (int k = 0; k < 4; k++) {
                 byte h = 0;
-				for(int j = 0; j < 4; j++) {
-					h = (byte)(h | ((l >> (j + 48 + (4 * k))) & 1));
-				}
+                for(int j = 0; j < 4; j++) {
+                    h = (byte)(h | ((l >> (j + 48 + (4 * k))) & 1));
+                }
                 c3 = (char) (c3 | (h << k));
             }
             builder.append(c).append(c1).append(c2).append(c3);
@@ -177,13 +177,13 @@ public class BlackboardBlockTile extends BlockEntity implements IOwnerProtected,
 
     public static long[] unpackPixelsFromString(String packed) {
         long[] unpacked = unpackPixelsFromStringWhiteOnly(packed);
-		if (packed.length() <= 64)
-			return unpacked;
+        if (packed.length() <= 64) {
+            return unpacked;
+        }
         var chars = packed.substring(64).toCharArray();
         int j = 0;
         for (int i = 0; i + 3 < chars.length && j < 16; i += 4) {
-            unpacked[j] = (unpacked[j] << 3) | (unpacked[j] << 2) | (unpacked[j] << 1);
-			unpacked[j] = unpacked[j] & ((long) chars[i + 3] << 48 | (long) chars[i + 2] << 32 | (long) chars[i + 1] << 16 | chars[i]);
+            unpacked[j] = (unpacked[j] * 15) & ((long) chars[i + 3] << 48 | (long) chars[i + 2] << 32 | (long) chars[i + 1] << 16 | chars[i]);
             j++;
         }
         return unpacked;


### PR DESCRIPTION
Firstly, this PR fixes a bug when input string is too large (possible ArrayIndexOutOfBoundsException and server crash)
https://github.com/MehVahdJukaar/Supplementaries/blob/d7d31879e057fc95c200fcf39430e763b83ee827/common/src/main/java/net/mehvahdjukaar/supplementaries/common/block/tiles/BlackboardBlockTile.java#L176

Secodly, it introduces a new encoding which is backwards compatible with monochrome encoding.

Here's a brief description of the encoding:
Encoding a monochrome image is achieved with the same(64 symbols) encoding, so it's backwards compatible.
Encoding a colored image is achieved by adding 64 more symbols ("Color mask")
So symbols 1-64 represents which pixels are going to be non-black, and symbols 64-128 represents the color of pixels (in the same format as in 1.16.5 version)

It also provides additional benefits:
1) It's now possible to encode 4 black pixels in a row.
With old 1.16.5 encoding scheme it wasn't possible to encode 4 pixels in a row, because it'd required pasting a \u0000 symbol, which is not possible. Now first 64 symbols determine which pixels are dark, so it's possible to select any image with display links.
2) It's easy to convert old(1.16.5) encoded images to the new format.
It's enough to prepend 64 '/'(slashes) to make all pixels non-black. Old color data just shifts into the "Color mask", setting color of these pixels. Since format of colored images is the same, it's going to represent the same image.