### PR TITLE
Ignore dye baskets from dye depot

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/configs/CommonConfigs.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/configs/CommonConfigs.java
@@ -721,7 +721,7 @@ public class CommonConfigs {
                             "mna:chimerite_crystal", "botania:floating_flower", ",minecraft:mushroom", "botania:mushroom",
                             "botania:tall_mystical_flower", "botania:petal_block", "morered:network_cable",
                             "xycraft_world:glowing_shiny_aurey_block", "xycraft_world:shiny_aurey_block", "xycraft_world:rgb_lamp",
-                            "xycraft_world:glowing_rgb_viewer", "xycraft_world:glowing_matte_rgb_block", "xycraft_world:rgb_lamp_pole"));
+                            "xycraft_world:glowing_rgb_viewer", "xycraft_world:glowing_matte_rgb_block", "xycraft_world:rgb_lamp_pole", "dye_depot:dye_basket"));
             SOAP_SPECIAL = builder.comment("This is a map of special blocks that can be cleaned with soap")
                     .defineObject("special_blocks", () -> Map.of(
                                     BlockPredicate.create("sticky_piston"), new ResourceLocation("piston"),

--- a/forge/update.json
+++ b/forge/update.json
@@ -1,7 +1,7 @@
 {
   "homepage": "https://www.curseforge.com/minecraft/mc-mods/supplementaries",
   "promos": {
-    "1.20-latest": "1.20-3.1.3",
-    "1.20-recommended": "1.20-3.1.3"
+    "1.20-latest": "1.20-3.1.20",
+    "1.20-recommended": "1.20-3.1.20"
   }
 }

--- a/forge/update.json
+++ b/forge/update.json
@@ -1,7 +1,7 @@
 {
   "homepage": "https://www.curseforge.com/minecraft/mc-mods/supplementaries",
   "promos": {
-    "1.20-latest": "1.20-3.1.20",
-    "1.20-recommended": "1.20-3.1.20"
+    "1.20-latest": "1.20-3.1.3",
+    "1.20-recommended": "1.20-3.1.3"
   }
 }


### PR DESCRIPTION
Saw that supplementaries creates soap cleaning recipes for the dye baskets from dye depot, which does not make any sense, since they are just storage blocks of the respective dyes. 
I looked into it and only saw the config option, which is why this PR adds it as a default there.
I would much rather have it as an item tag tho, I understand that users  still want config options, but an additional check for a blacklist item tag would make it for other mod developers much easier.

![image](https://github.com/user-attachments/assets/9de1d9ab-a643-4e14-a152-b9f946b15e21)
