### PR TITLE
add item/block tags to blacklist items from being cleaned with soap

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/items/crafting/SoapClearRecipe.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/items/crafting/SoapClearRecipe.java
@@ -1,6 +1,7 @@
 package net.mehvahdjukaar.supplementaries.common.items.crafting;
 
 import net.mehvahdjukaar.moonlight.api.set.BlocksColorAPI;
+import net.mehvahdjukaar.supplementaries.common.utils.SoapWashableHelper;
 import net.mehvahdjukaar.supplementaries.configs.CommonConfigs;
 import net.mehvahdjukaar.supplementaries.reg.ModRecipes;
 import net.mehvahdjukaar.supplementaries.reg.ModRegistry;
@@ -30,7 +31,7 @@ public class SoapClearRecipe extends CustomRecipe {
             if (!itemstack.isEmpty()) {
                 Item item = itemstack.getItem();
                 boolean isColored = (BlocksColorAPI.getColor(item) != null &&
-                        !CommonConfigs.Functional.SOAP_DYE_CLEAN_BLACKLIST.get().contains(BlocksColorAPI.getKey(item)));
+                        SoapWashableHelper.canCleanColor(item));
                 if (isColored || item instanceof DyeableLeatherItem || hasTrim(item)) {
                     ++i;
                 } else {

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/items/crafting/SpecialRecipeDisplays.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/items/crafting/SpecialRecipeDisplays.java
@@ -6,6 +6,7 @@ import net.mehvahdjukaar.supplementaries.Supplementaries;
 import net.mehvahdjukaar.supplementaries.common.block.tiles.BlackboardBlockTile;
 import net.mehvahdjukaar.supplementaries.common.items.AntiqueInkItem;
 import net.mehvahdjukaar.supplementaries.common.items.BambooSpikesTippedItem;
+import net.mehvahdjukaar.supplementaries.common.utils.SoapWashableHelper;
 import net.mehvahdjukaar.supplementaries.configs.CommonConfigs;
 import net.mehvahdjukaar.supplementaries.integration.CompatHandler;
 import net.mehvahdjukaar.supplementaries.reg.ModRegistry;
@@ -113,9 +114,9 @@ public class SpecialRecipeDisplays {
         String group = "supplementaries.soap";
 
         for (String k : BlocksColorAPI.getBlockKeys()) {
-            if (!CommonConfigs.Functional.SOAP_DYE_CLEAN_BLACKLIST.get().contains(k)) {
+            Item out = BlocksColorAPI.getColoredItem(k, null);
+            if (SoapWashableHelper.canCleanColor(out)) {
                 var n = BlocksColorAPI.getItemHolderSet(k);
-                Item out = BlocksColorAPI.getColoredItem(k, null);
                 if (n == null || out == null) continue;
 
                 Ingredient ing = n.unwrap().map(Ingredient::of, l ->

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/utils/SoapWashableHelper.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/utils/SoapWashableHelper.java
@@ -7,12 +7,14 @@ import net.mehvahdjukaar.supplementaries.SuppPlatformStuff;
 import net.mehvahdjukaar.supplementaries.common.network.ClientBoundParticlePacket;
 import net.mehvahdjukaar.supplementaries.common.network.ModNetwork;
 import net.mehvahdjukaar.supplementaries.configs.CommonConfigs;
+import net.mehvahdjukaar.supplementaries.reg.ModTags;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.HoneycombItem;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -21,6 +23,16 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 
 public class SoapWashableHelper {
+
+    public static boolean canCleanColor(Block block) {
+        if (block.builtInRegistryHolder().is(ModTags.SOAP_BLACKLIST_BLOCK)) return false;
+        return !CommonConfigs.Functional.SOAP_DYE_CLEAN_BLACKLIST.get().contains(BlocksColorAPI.getKey(block));
+    }
+
+    public static boolean canCleanColor(Item item) {
+        if (item.builtInRegistryHolder().is(ModTags.SOAP_BLACKLIST_ITEM)) return false;
+        return !CommonConfigs.Functional.SOAP_DYE_CLEAN_BLACKLIST.get().contains(BlocksColorAPI.getKey(item));
+    }
 
     //support: waxed, forge waxed, copper, IW stuff
     public static boolean tryWash(Level level, BlockPos pos, BlockState state, Vec3 hitVec) {
@@ -140,8 +152,7 @@ public class SoapWashableHelper {
         Block newColor = BlocksColorAPI.changeColor(state.getBlock(), null);
 
         if (newColor != null) {
-            if (CommonConfigs.Functional.SOAP_DYE_CLEAN_BLACKLIST.get()
-                    .contains(BlocksColorAPI.getKey(state.getBlock()))) return false;
+            if (!canCleanColor(state.getBlock())) return false;
 
             //TODO: add back
             if (state.getBlock() instanceof BedBlock) {

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/reg/ModTags.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/reg/ModTags.java
@@ -51,6 +51,7 @@ public class ModTags {
     public static final TagKey<Block> FAST_FALL_ROPES = blockTag("fast_fall_climbable");
     public static final TagKey<Block> BOUNCY_BLOCKS = blockTag("bouncy_blocks");
     public static final TagKey<Block> TURN_TABLE_CANT_SHUFFLE = blockTag("turn_table_cant_shuffle");
+    public static final TagKey<Block> SOAP_BLACKLIST_BLOCK = blockTag("non_cleanable");
 
     //item tags
     public static final TagKey<Item> SHULKER_BLACKLIST_TAG = itemTag("shulker_blacklist");
@@ -78,6 +79,7 @@ public class ModTags {
     public static final TagKey<Item> QUIVER_WHITELIST = itemTag("quiver_blacklist");
     public static final TagKey<Item> IGNITE_FLINT_BLOCKS = itemTag("ignite_flint_blocks");
     public static final TagKey<Item> LUNCH_BASKET_BLACKLIST = itemTag("lunch_basket_blacklist");
+    public static final TagKey<Item> SOAP_BLACKLIST_ITEM = itemTag("non_cleanable");
 
     public static final TagKey<Item> SHULKER_BOXES = MCitemTag("shulker_boxes");
 


### PR DESCRIPTION
Add additional checks against an blacklist item/block tag for soap functionalities.
Since the recipes could have an input which is a tag itself instead of a list of items, this means that the check is actually done against the output item. Sounds counterintuitive at first, but since mod authors will add all of the colored variants to the tag, it will also work since the "white" variant should also be in there