### PR TITLE
[1.21] Remove duplicate entry in #supplementaries:hourglass_dusts

### DIFF
--- a/common/src/main/resources/data/supplementaries/tags/item/hourglass_dusts.json
+++ b/common/src/main/resources/data/supplementaries/tags/item/hourglass_dusts.json
@@ -1,4 +1,3 @@
-
 {
   "replace": false,
   "values": [
@@ -17,7 +16,6 @@
     {"id":"shretnether:ashpile","required":false},
     {"id":"infernalexp:moth_dust","required":false},
     {"id":"infernalexp:basalt_silt","required":false},
-    {"id":"create:powdered_obsidian","required":false},
     {"id":"feywild:fey_dust","required":false},
     {"id":"create:cinder_flour","required":false},
     {"id":"create:powdered_obsidian","required":false},


### PR DESCRIPTION
`create:powdered_obsidian` was in the tag twice