### PR TITLE
Trapped present detonation fix

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/block/blocks/TrappedPresentBlock.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/block/blocks/TrappedPresentBlock.java
@@ -130,7 +130,7 @@ public class TrappedPresentBlock extends AbstractPresentBlock implements ILighta
 
     @Override
     public boolean lightUp(@Nullable Entity player, BlockState state, BlockPos pos, LevelAccessor world, FireSourceType fireSourceType) {
-        if (this.isLitUp(state, world, pos) && world.getBlockEntity(pos) instanceof TrappedPresentBlockTile tile) {
+        if (state.getValue(PACKED) && !state.getValue(ON_COOLDOWN) && world.getBlockEntity(pos) instanceof TrappedPresentBlockTile tile) {
             if (world instanceof ServerLevel serverLevel) {
                 tile.detonate(serverLevel, pos, state, null);
             }


### PR DESCRIPTION
Fixes issue where trapped presents could only lightUp if they were *already* isLitUp, effectively meaning they could only be set off directly by a player rather than via gunpowder or redstone.