### PR TITLE
Fix `betteranimalsplus_flying_fish.json`

### DIFF
--- a/common/src/main/resources/data/supplementaries/catchable_mobs_properties/betteranimalsplus_flying_fish.json
+++ b/common/src/main/resources/data/supplementaries/catchable_mobs_properties/betteranimalsplus_flying_fish.json
@@ -1,5 +1,6 @@
 {
-  "force_fluid": "minecraft:water",+"fish_index": 35,
+  "render_fluid": "moonlight:water",
+  "fish_index": 35,
   "height_increment": 0.0,
   "owners": [
     "betteranimalsplus:flying_fish"


### PR DESCRIPTION
Removed extra `+` sign that causes errors in logs.

Fixes this error:
```log
[Worker-ResourceReload-3/ERROR] [net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener/]: Couldn't parse data file supplementaries:betteranimalsplus_flying_fish from supplementaries:catchable_mobs_properties/betteranimalsplus_flying_fish.json
com.google.gson.JsonParseException: com.google.gson.stream.MalformedJsonException: Use JsonReader.setLenient(true) to accept malformed JSON at line 2 column 38 path $.render_fluid
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.util.GsonHelper.fromNullableJson(GsonHelper.java:527) ~[client-1.21.1-20240808.144430-srg.jar%23492!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.util.GsonHelper.fromJson(GsonHelper.java:532) ~[client-1.21.1-20240808.144430-srg.jar%23492!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.util.GsonHelper.fromJson(GsonHelper.java:582) ~[client-1.21.1-20240808.144430-srg.jar%23492!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener.scanDirectory(SimpleJsonResourceReloadListener.java:42) ~[client-1.21.1-20240808.144430-srg.jar%23492!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener.prepare(SimpleJsonResourceReloadListener.java:30) ~[client-1.21.1-20240808.144430-srg.jar%23492!/:?]
	at TRANSFORMER/supplementaries@1.21-3.1.4/net.mehvahdjukaar.supplementaries.common.misc.mob_container.CapturedMobHandler.prepare(CapturedMobHandler.java:30) ~[supplementaries-1.21-3.1.4-neoforge.jar%23762!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.packs.resources.SimplePreparableReloadListener.lambda$reload$0(SimplePreparableReloadListener.java:17) ~[client-1.21.1-20240808.144430-srg.jar%23492!/:?]
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) [?:?]
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1760) [?:?]
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387) [?:?]
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312) [?:?]
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843) [?:?]
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808) [?:?]
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188) [?:?]
Caused by: com.google.gson.stream.MalformedJsonException: Use JsonReader.setLenient(true) to accept malformed JSON at line 2 column 38 path $.render_fluid
	at MC-BOOTSTRAP/com.google.gson@2.10.1/com.google.gson.stream.JsonReader.syntaxError(JsonReader.java:1659) ~[gson-2.10.1.jar%23105!/:?]
	at MC-BOOTSTRAP/com.google.gson@2.10.1/com.google.gson.stream.JsonReader.checkLenient(JsonReader.java:1465) ~[gson-2.10.1.jar%23105!/:?]
	at MC-BOOTSTRAP/com.google.gson@2.10.1/com.google.gson.stream.JsonReader.doPeek(JsonReader.java:517) ~[gson-2.10.1.jar%23105!/:?]
	at MC-BOOTSTRAP/com.google.gson@2.10.1/com.google.gson.stream.JsonReader.hasNext(JsonReader.java:422) ~[gson-2.10.1.jar%23105!/:?]
	at MC-BOOTSTRAP/com.google.gson@2.10.1/com.google.gson.internal.bind.TypeAdapters$28.read(TypeAdapters.java:779) ~[gson-2.10.1.jar%23105!/:?]
	at MC-BOOTSTRAP/com.google.gson@2.10.1/com.google.gson.internal.bind.TypeAdapters$28.read(TypeAdapters.java:725) ~[gson-2.10.1.jar%23105!/:?]
	at MC-BOOTSTRAP/com.google.gson@2.10.1/com.google.gson.internal.bind.TypeAdapters$34$1.read(TypeAdapters.java:1007) ~[gson-2.10.1.jar%23105!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.util.GsonHelper.fromNullableJson(GsonHelper.java:525) ~[client-1.21.1-20240808.144430-srg.jar%23492!/:?]
	... 13 more
```