### PR TITLE
Fix flower box tooltip

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/block/blocks/FlowerBoxBlock.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/block/blocks/FlowerBoxBlock.java
@@ -66,7 +66,7 @@ public class FlowerBoxBlock extends WaterBlock implements EntityBlock {
     @Override
     public void appendHoverText(ItemStack stack, BlockGetter context, List<Component> tooltipComponents, TooltipFlag tooltipFlag) {
         super.appendHoverText(stack, context, tooltipComponents, tooltipFlag);
-        if (!MiscUtils.showsHints(context,tooltipFlag) || CommonConfigs.Building.FLOWER_BOX_SIMPLE_MODE.get()) return;
+        if (!MiscUtils.showsHints(context,tooltipFlag) || !CommonConfigs.Building.FLOWER_BOX_SIMPLE_MODE.get()) return;
         tooltipComponents.add((Component.translatable("message.supplementaries.flower_box")).withStyle(ChatFormatting.GRAY).withStyle(ChatFormatting.ITALIC));
     }
 


### PR DESCRIPTION
Fixes issue where the tooltip for flower boxes (which describes their simple-mode functionality) is only shown if they *aren't* set to simple mode