### PR TITLE
Make vanilla status effects optional in tipped_spikes_blacklist

### DIFF
--- a/common/src/main/resources/data/supplementaries/tags/potion/tipped_spikes_blacklist.json
+++ b/common/src/main/resources/data/supplementaries/tags/potion/tipped_spikes_blacklist.json
@@ -1,8 +1,14 @@
 {
   "replace": false,
   "values": [
-    "minecraft:oozing",
-    "minecraft:infested",
+    {
+      "id": "minecraft:oozing",
+      "required": false
+    },
+    {
+      "id": "minecraft:infested",
+      "required": false
+    },
     {
       "id": "ars_nouveau:blasting",
       "required": false


### PR DESCRIPTION
This modifies the tipped_spikes_blacklist tag to make make vanilla status effects optional. These status effects were only introduced in 1.20.5. This means loading this tag fails silently in 1.20.1 builds of Supplementaries.