### PR TITLE
Rename "Candy" to "Sweet" in UK English

### DIFF
--- a/common/src/main/resources/assets/supplementaries/lang/en_gb.json
+++ b/common/src/main/resources/assets/supplementaries/lang/en_gb.json
@@ -570,5 +570,6 @@
   "item.supplementaries.sign_post_rotten_lotr": "Rotten Sign Post",
   "item.supplementaries.sign_post_runewood": "Runewood Sign Post",
   "item.supplementaries.sign_post_archwood": "Archwood Sign Post",
-  "block.supplementaries.gunpowder": "Gunpowder"
+  "block.supplementaries.gunpowder": "Gunpowder",
+  "item.supplementaries.candy": "Sweet"
 }


### PR DESCRIPTION
Candy is an American term that is not used in British English. I have fixed the `en_gb.json` file to make use of the term "sweet" instead.