### PR TITLE
Update caverns_and_chasms:altimeter to caverns_and_chasms:depth_gauge

### DIFF
--- a/common/src/main/resources/data/supplementaries/tags/items/altimeters.json
+++ b/common/src/main/resources/data/supplementaries/tags/items/altimeters.json
@@ -1,8 +1,8 @@
 {
   "replace": false,
   "values": [
-    {"id":"spelunkery:depth_gauge","required":false},
     {"id":"supplementaries:altimeter","required":true},
-    {"id":"caverns_and_chasms:altimeter","required":false}
+    {"id":"spelunkery:depth_gauge","required":false},
+    {"id":"caverns_and_chasms:depth_gauge","required":false}
   ]
 }


### PR DESCRIPTION
The item id `caverns_and_chasms:altimeter` should be `caverns_and_chasms:depth_gauge` in the `supplementaries:altimeter` tag.