### PR TITLE
Fix Cupric Candle Holder recipe and make Candle Holder recipes consistent

### DIFF
--- a/common/src/main/resources/data/supplementaries/recipes/candle_holders/candle_holder.json
+++ b/common/src/main/resources/data/supplementaries/recipes/candle_holders/candle_holder.json
@@ -1,6 +1,7 @@
 {
   "type": "minecraft:crafting_shaped",
   "category": "building",
+  "group": "candle_holder",
   "pattern": [
     "NCN",
     " N "

--- a/common/src/main/resources/data/supplementaries/recipes/candle_holders/candle_holder_cupric.json
+++ b/common/src/main/resources/data/supplementaries/recipes/candle_holders/candle_holder_cupric.json
@@ -13,7 +13,7 @@
     }
   },
   "result": {
-    "item": "supplementaries:candle_holder_ender",
+    "item": "supplementaries:candle_holder_cupric",
     "count": 1
   },
   "conditions": [

--- a/common/src/main/resources/data/supplementaries/recipes/candle_holders/candle_holder_cupric.json
+++ b/common/src/main/resources/data/supplementaries/recipes/candle_holders/candle_holder_cupric.json
@@ -1,14 +1,16 @@
 {
   "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "group": "candle_holder",
   "pattern": [
-    "1",
-    "2"
+    "NCN",
+    " N "
   ],
   "key": {
-    "1": {
+    "C": {
       "item": "buzzier_bees:cupric_candle"
     },
-    "2": {
+    "N": {
       "item": "minecraft:iron_ingot"
     }
   },

--- a/common/src/main/resources/data/supplementaries/recipes/candle_holders/candle_holder_ender.json
+++ b/common/src/main/resources/data/supplementaries/recipes/candle_holders/candle_holder_ender.json
@@ -1,14 +1,16 @@
 {
   "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "group": "candle_holder",
   "pattern": [
-    "1",
-    "2"
+    "NCN",
+    " N "
   ],
   "key": {
-    "1": {
+    "C": {
       "item": "buzzier_bees:ender_candle"
     },
-    "2": {
+    "N": {
       "item": "minecraft:iron_ingot"
     }
   },

--- a/common/src/main/resources/data/supplementaries/recipes/candle_holders/candle_holder_soul.json
+++ b/common/src/main/resources/data/supplementaries/recipes/candle_holders/candle_holder_soul.json
@@ -1,14 +1,16 @@
 {
   "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "group": "candle_holder",
   "pattern": [
-    "1",
-    "2"
+    "NCN",
+    " N "
   ],
   "key": {
-    "1": {
+    "C": {
       "item": "buzzier_bees:soul_candle"
     },
-    "2": {
+    "N": {
       "item": "minecraft:iron_ingot"
     }
   },

--- a/common/src/main/resources/data/supplementaries/recipes/candle_holders/candle_holder_spectacle.json
+++ b/common/src/main/resources/data/supplementaries/recipes/candle_holders/candle_holder_spectacle.json
@@ -1,14 +1,16 @@
 {
   "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "group": "candle_holder",
   "pattern": [
-    "1",
-    "2"
+    "NCN",
+    " N "
   ],
   "key": {
-    "1": {
+    "C": {
       "item": "cave_enhancements:spectacle_candle"
     },
-    "2": {
+    "N": {
       "item": "minecraft:iron_ingot"
     }
   },


### PR DESCRIPTION
- Fixed Cupric Candle Holder recipe resulting in Ender Candle Holder
- Made the modded Candle Holder recipes consistent with other candle holders by making them require 3 ingots instead of 1