### PR TITLE
Add a Cannon peripheral

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     if (isMyPc) {
         modImplementation("net.mehvahdjukaar:moonlight:${moonlight_version}")
     } else {
-        modImplementation("curse.maven:selene-499980:6818413")
+        modImplementation("curse.maven:selene-499980:7007381")
     }
 
     modCompileOnly("curse.maven:irisshaders-455508:5726473")

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/block/tiles/CannonBlockTile.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/block/tiles/CannonBlockTile.java
@@ -46,6 +46,7 @@ import java.util.UUID;
 
 public class CannonBlockTile extends OpeneableContainerBlockEntity implements IOnePlayerInteractable {
 
+    public Object ccHack = null;
 
     //no list = normal behavior. empty list = cant break anything
     //not using a tag as this is meant to be edited with commands immediately without a tag being there

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     if (isMyPc) {
         modImplementation("net.mehvahdjukaar:moonlight-fabric:${moonlight_version}")
     } else {
-        modImplementation("curse.maven:selene-499980:6939533")
+        modImplementation("curse.maven:selene-499980:7007382")
     }
 
     modCompileOnly("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_version}") {

--- a/fabric/src/main/java/net/mehvahdjukaar/supplementaries/integration/fabric/CCCompatImpl.java
+++ b/fabric/src/main/java/net/mehvahdjukaar/supplementaries/integration/fabric/CCCompatImpl.java
@@ -5,7 +5,10 @@ import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.api.peripheral.PeripheralLookup;
 import dan200.computercraft.shared.media.items.PrintoutData;
 import dan200.computercraft.shared.media.items.PrintoutItem;
+import net.mehvahdjukaar.moonlight.api.misc.TileOrEntityTarget;
 import net.mehvahdjukaar.moonlight.fabric.MoonlightFabric;
+import net.mehvahdjukaar.supplementaries.common.block.cannon.CannonAccess;
+import net.mehvahdjukaar.supplementaries.common.block.tiles.CannonBlockTile;
 import net.mehvahdjukaar.supplementaries.common.block.tiles.SpeakerBlockTile;
 import net.mehvahdjukaar.supplementaries.reg.ModRegistry;
 import net.minecraft.network.chat.Component;
@@ -22,6 +25,10 @@ public class CCCompatImpl {
         PeripheralLookup.get().registerForBlocks((world, pos, state, blockEntity, context) -> {
                     if (blockEntity instanceof SpeakerBlockTile t) {
                         if (t.ccHack == null) t.ccHack = new SpeakerPeripheral(t);
+                        return (IPeripheral) t.ccHack;
+                    }
+                    if (blockEntity instanceof CannonBlockTile t) {
+                        if (t.ccHack == null) t.ccHack = new CannonPeripheral(t);
                         return (IPeripheral) t.ccHack;
                     }
                     return null;
@@ -133,6 +140,73 @@ public class CCCompatImpl {
         @Override
         public String toString() {
             return "SpeakerPeripheral[" +
+                    "tile=" + tile + ']';
+        }
+
+    }
+
+
+
+    public static final class CannonPeripheral implements IPeripheral {
+        private final CannonBlockTile tile;
+        private final CannonAccess acc;
+
+        public CannonPeripheral(CannonBlockTile tile) {
+            this.tile = tile;
+            this.acc = CannonAccess.find(tile.getLevel(), TileOrEntityTarget.of(tile));
+        }
+
+        @LuaFunction
+        public void setYaw(float value) {
+            tile.setYaw(acc, value);
+        }
+        @LuaFunction
+        public float getYaw() {
+            return tile.getYaw();
+        }
+        @LuaFunction
+        public void setPitch(float value) {
+            tile.setPitch(acc, value);
+        }
+        @LuaFunction
+        public float getPitch() {
+            return tile.getPitch();
+        }
+        @LuaFunction
+        public void setPower(byte power) {
+            power = (byte) Math.min(Math.max(power, 0), 4); // todo improve when there is a system similar to pitch/yaw restraints for power
+            tile.setPowerLevel(power);
+        }
+        @LuaFunction
+        public byte getPower() {
+            return tile.getPowerLevel();
+        }
+        @LuaFunction
+        public void ignite() {
+            tile.ignite(null, acc);
+        }
+
+        @Override
+        public String getType() {
+            return "cannon";
+        }
+
+        @Override
+        public boolean equals(@Nullable IPeripheral obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (CannonPeripheral) obj;
+            return Objects.equals(this.tile, that.tile);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(tile);
+        }
+
+        @Override
+        public String toString() {
+            return "CannonPeripheral[" +
                     "tile=" + tile + ']';
         }
 

--- a/fabric/src/main/java/net/mehvahdjukaar/supplementaries/integration/fabric/CCCompatImpl.java
+++ b/fabric/src/main/java/net/mehvahdjukaar/supplementaries/integration/fabric/CCCompatImpl.java
@@ -27,13 +27,17 @@ public class CCCompatImpl {
                         if (t.ccHack == null) t.ccHack = new SpeakerPeripheral(t);
                         return (IPeripheral) t.ccHack;
                     }
+                    return null;
+                }
+                , ModRegistry.SPEAKER_BLOCK.get());
+        PeripheralLookup.get().registerForBlocks((world, pos, state, blockEntity, context) -> {
                     if (blockEntity instanceof CannonBlockTile t) {
                         if (t.ccHack == null) t.ccHack = new CannonPeripheral(t);
                         return (IPeripheral) t.ccHack;
                     }
                     return null;
                 }
-                , ModRegistry.SPEAKER_BLOCK.get());
+                , ModRegistry.CANNON.get());
     }
 
     public static int getPages(ItemStack itemstack) {
@@ -157,25 +161,28 @@ public class CCCompatImpl {
         }
 
         @LuaFunction
-        public void setYaw(float value) {
-            tile.setYaw(acc, value);
+        public void setYaw(double value) {
+            tile.setYaw(acc, (float) value);
+            acc.updateClients();
         }
         @LuaFunction
         public float getYaw() {
             return tile.getYaw();
         }
         @LuaFunction
-        public void setPitch(float value) {
-            tile.setPitch(acc, value);
+        public void setPitch(double value) {
+            tile.setPitch(acc, (float) value);
+            acc.updateClients();
         }
         @LuaFunction
         public float getPitch() {
             return tile.getPitch();
         }
         @LuaFunction
-        public void setPower(byte power) {
-            power = (byte) Math.min(Math.max(power, 0), 4); // todo improve when there is a system similar to pitch/yaw restraints for power
+        public void setPower(int inPower) {
+            byte power = (byte) Math.min(Math.max(inPower, 1), 4); // todo improve when there is a system similar to pitch/yaw restraints for power
             tile.setPowerLevel(power);
+            acc.updateClients();
         }
         @LuaFunction
         public byte getPower() {

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -103,7 +103,7 @@ dependencies {
         modImplementation("net.mehvahdjukaar:moonlight-neoforge:${moonlight_version}")
         modCompileOnly("net.mehvahdjukaar:suppsquared-neoforge:1.21-1.2.6")
     } else {
-        modImplementation("curse.maven:selene-499980:6818413")
+        modImplementation("curse.maven:selene-499980:7007381")
     }
 
     modCompileOnly("curse.maven:farmers-delight-398521:5772720")

--- a/neoforge/src/main/java/net/mehvahdjukaar/supplementaries/integration/neoforge/CCCompatImpl.java
+++ b/neoforge/src/main/java/net/mehvahdjukaar/supplementaries/integration/neoforge/CCCompatImpl.java
@@ -177,25 +177,28 @@ public class CCCompatImpl {
         }
 
         @LuaFunction
-        public void setYaw(float value) {
-            tile.setYaw(acc, value);
+        public void setYaw(double value) {
+            tile.setYaw(acc, (float) value);
+            acc.updateClients();
         }
         @LuaFunction
         public float getYaw() {
             return tile.getYaw();
         }
         @LuaFunction
-        public void setPitch(float value) {
-            tile.setPitch(acc, value);
+        public void setPitch(double value) {
+            tile.setPitch(acc, (float) value);
+            acc.updateClients();
         }
         @LuaFunction
         public float getPitch() {
             return tile.getPitch();
         }
         @LuaFunction
-        public void setPower(byte power) {
-            power = (byte) Math.min(Math.max(power, 0), 4); // todo improve when there is a system similar to pitch/yaw restraints for power
+        public void setPower(int inPower) {
+            byte power = (byte) Math.min(Math.max(inPower, 1), 4); // todo improve when there is a system similar to pitch/yaw restraints for power
             tile.setPowerLevel(power);
+            acc.updateClients();
         }
         @LuaFunction
         public byte getPower() {


### PR DESCRIPTION
Add a cannon peripheral with 7 functions:

- `void setYaw(double)` Sets yaw of the cannon and sends an update to players
- `double getYaw()` Gets yaw of the cannon
- `void setPitch(double)` Ditto 1
- `double getPitch()` Ditto 2
- `void setPower(int)` Ditto 1
- `double getPower()` Ditto 2
- `void ignite()` Shoots the cannon