### PR TITLE
Fix: Zombie horse data lost on reload

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/mixins/ZombieHorseMixin.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/mixins/ZombieHorseMixin.java
@@ -65,7 +65,7 @@ public abstract class ZombieHorseMixin extends AbstractHorse implements IConvert
 
     @Override
     public void readAdditionalSaveData(CompoundTag compoundNBT) {
-        this.addAdditionalSaveData(compoundNBT);
+        super.readAdditionalSaveData(compoundNBT);
         this.supplementaries$conversionTime = compoundNBT.getInt("ConversionTime");
     }
 


### PR DESCRIPTION
Replace call to this.addAdditionalSaveData(compoundNBT) with super.readAdditionalSaveData(compoundNBT) to properly load zombie horse data.

Fixes #1123 