### PR TITLE
Fix typo in Galleon's Safe loot table

### DIFF
--- a/common/src/main/resources/data/supplementaries/loot_table/loot/galleon/safe.json
+++ b/common/src/main/resources/data/supplementaries/loot_table/loot/galleon/safe.json
@@ -189,7 +189,7 @@
           "functions": [
             {
               "function": "minecraft:enchant_randomly",
-              "options": "#minecraft:galleon_treasure"
+              "options": "#supplementaries:galleon_treasure"
             }
           ],
           "name": "minecraft:book",


### PR DESCRIPTION
I didn't feel like reporting it as an issue only this time.

```
Not all defined tags for registry ResourceKey[minecraft:root / minecraft:enchantment] are present in data pack: minecraft:galleon_treasure
```

I am fully confident this was intended to be `#supplementaries:galleon_treasure`, given that's what the existing tag is.

I don't know why Github removed the trailing space at the end here.