### PR TITLE
Update the link leading to Amendments to point to the correct site.

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/client/screens/WelcomeMessageScreen.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/client/screens/WelcomeMessageScreen.java
@@ -138,7 +138,7 @@ public class WelcomeMessageScreen extends Screen {
 
     private static final Component AM_URL = Component.translatable("gui.supplementaries.amendments.suggestions")
             .withStyle(Style.EMPTY.withColor(ChatFormatting.GREEN).applyFormat(ChatFormatting.UNDERLINE)
-                    .withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, "https://legacy.curseforge.com/minecraft/mc-mods/amendments")));
+                    .withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, "https://www.curseforge.com/minecraft/mc-mods/amendments")));
 
     private static final Component AM_TITLE = Component.translatable("gui.supplementaries.amendments.title")
             .withStyle(ChatFormatting.GOLD).withStyle(ChatFormatting.BOLD);


### PR DESCRIPTION
As a general rule of thumb, you should never use legacy CurseForge links in mods. It's deprecated.

It's a very easy fix and the updated link should point to the new version. You never know when legacy links might break one day.