### PR TITLE
Allow Fire Pit to be used for Create's Bulk Smoking

### DIFF
--- a/common/src/main/resources/data/create/tags/block/fan_processing_catalysts/smoking.json
+++ b/common/src/main/resources/data/create/tags/block/fan_processing_catalysts/smoking.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    {"id":"supplementaries:fire_pit","required":false}
+  ]
+}


### PR DESCRIPTION
This PR allows the Fire Pit to be placed in front of a spinning Encased Fan for Create's bulk smoking. This was a thing in my modpack that I thought to be fairly reasonable to have in the base mod, especially given the existing Create "compatibility" in Supplementaries. No hard feelings if this is deemed to be too much, though.