### PR TITLE
Fix slingshot projectile removal logic

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/entities/SlingshotProjectileEntity.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/entities/SlingshotProjectileEntity.java
@@ -142,8 +142,9 @@ public class SlingshotProjectileEntity extends ImprovedProjectileEntity implemen
     protected void onHitEntity(EntityHitResult entityRayTraceResult) {
         super.onHitEntity(entityRayTraceResult);
         ItemStack stack = this.getItem();
-        if (!trySplashPotStuff() &&
-                entityRayTraceResult.getEntity() instanceof EnderMan enderman) {
+        if (trySplashPotStuff()) {
+            this.remove(RemovalReason.DISCARDED);
+        } else if (entityRayTraceResult.getEntity() instanceof EnderMan enderman) {
             Item item = stack.getItem();
             if (item instanceof BlockItem bi) {
                 Block block = bi.getBlock();
@@ -233,7 +234,9 @@ public class SlingshotProjectileEntity extends ImprovedProjectileEntity implemen
                     this.setItem(craftingRemainingItem.getDefaultInstance());
                 } else shoulKill = true;
             }
-            this.isStuck = true;
+            if (!shoulKill) {
+                this.isStuck = true;
+            }
         }
         if (shoulKill) {
             this.remove(RemovalReason.DISCARDED);


### PR DESCRIPTION
## Description
Fixes two logic issues in the slingshot projectile entity:

1. **onHitEntity**: When a splash potion is successfully applied ( returns true), the projectile wasn't being removed. Now properly removes the entity after handling the splash effect.

2. **Stuck state**: Only mark the projectile as stuck if it won't be removed. This prevents unnecessary state changes when the entity is about to be discarded anyway.

These changes ensure cleaner entity lifecycle management and prevent edge cases where projectiles remain in an inconsistent state.

Fixes #1900