### PR TITLE
Fix typo in `c:dyed/brown` block tag definition

### DIFF
--- a/common/src/main/resources/data/c/tags/block/dyed/brown.json
+++ b/common/src/main/resources/data/c/tags/block/dyed/brown.json
@@ -7,7 +7,7 @@
     "supplementaries:candle_holder_brown",
     "supplementaries:awning_brown",
     "supplementaries:bunting_brown",
-    "supplementaries:bunting__wall_brown"
+    "supplementaries:bunting_wall_brown"
 
   ]
 }


### PR DESCRIPTION
In `c:dyed/brown`, `supplementaries:bunting_wall_brown` was written as `supplementaries:bunting__wall_brown`

Load my F***ing tags was throwing an error, so I figured after opening so many issues, I'd contribute to the project, since this was something I could actually do myself !

It's my first time contributing to a project other than my own team's, so I hope I did things correctly !