### PR TITLE
Fix Wall Way Sign block not tagged as a sign

### DIFF
--- a/common/src/main/resources/data/minecraft/tags/block/all_signs.json
+++ b/common/src/main/resources/data/minecraft/tags/block/all_signs.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
-    "supplementaries:way_sign"
-    ]
+    "supplementaries:way_sign",
+    "supplementaries:way_sign_wall"
+  ]
 }


### PR DESCRIPTION
I don't know how this went quietly unnoticed but

See also https://github.com/RasaNovum/Via_Romana/issues/102#issuecomment-4005928911