### PR TITLE
Fix Doormat not playing its own footstep noises

### DIFF
--- a/common/src/main/resources/data/minecraft/tags/block/combination_step_sound_blocks.json
+++ b/common/src/main/resources/data/minecraft/tags/block/combination_step_sound_blocks.json
@@ -1,5 +1,6 @@
 {
   "values": [
-    "supplementaries:ash"
+    "supplementaries:ash",
+    "supplementaries:doormat"
   ]
 }


### PR DESCRIPTION
When stepping onto a Doormat, the sound that plays is of the block underneath. This PR adds the Doormat to the proper tag to fix it, akin to carpets.

I've discovered a bunch of other mods that missed this tag in the pursuit of upgrading Minecraft versions, as well. Just food for thought. There may be a few more blocks in Supplementaries that need it.