### PR TITLE
Fix Pancake and Bamboo Spikes not always playing their footstep noises

### DIFF
--- a/common/src/main/resources/data/minecraft/tags/block/inside_step_sound_blocks.json
+++ b/common/src/main/resources/data/minecraft/tags/block/inside_step_sound_blocks.json
@@ -1,6 +1,8 @@
 {
   "values": [
     "supplementaries:ash",
-    "supplementaries:barnacles"
+    "supplementaries:bamboo_spikes",
+    "supplementaries:barnacles",
+    "supplementaries:pancake"
   ]
 }


### PR DESCRIPTION
Similar to https://github.com/MehVahdJukaar/Supplementaries/pull/1922 , this PR adds **Pancake** and **Bamboo Spikes** to the `minecraft:combination_step_sound_blocks` (similar to Wool Carpets).

This is a separate PR because it could use a few more opinions, depending on what these blocks are considered to be "made of", and which tag would make the most sense. It's a tie between between `minecraft:inside_step_sound_blocks` and `minecraft:combination_step_sound_blocks`, whose main difference is whether the underlying block can be heard at all.

I was considering including the **Crank** here (as I did for myself), but because it has no physical collision it'd be even more opinionated.

Do also note that by adding either of those tags, the Bamboo Spikes' footstep noise also plays when walking besides them while they're attached to the side. This is a merely a quirk of how Minecraft handles footsteps in the first place. It can also be experienced with Barnacles, Glow Lichen, Sculk Veins, etc.