### PR TITLE
Fix wrong `create:brittle` tag, properly allow more blocks on Create's Contraptions

### DIFF
--- a/common/src/main/resources/data/create/tags/block/brittle.json
+++ b/common/src/main/resources/data/create/tags/block/brittle.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "values": [
+    {"id":"#supplementaries:candle_holders","required":false},
+    {"id":"#supplementaries:sconces","required":false},
+    {"id":"#supplementaries:buntings","required":false},
+    {"id":"supplementaries:ash","required":false},
+    {"id":"supplementaries:barnacles","required":false},
+    {"id":"supplementaries:crank","required":false},
+    {"id":"supplementaries:doormat","required":false},
+    {"id":"supplementaries:item_shelf","required":false},
+    {"id":"supplementaries:pancake","required":false},
+    {"id":"supplementaries:sconce_lever","required":false}
+  ]
+}

--- a/common/src/main/resources/data/create/tags/item/brittle.json
+++ b/common/src/main/resources/data/create/tags/item/brittle.json
@@ -1,8 +1,0 @@
-{
-  "replace": false,
-  "values": [
-    {"id":"#supplementaries:candle_holders","required":false},
-    {"id":"#supplementaries:sconces","required":false},
-    {"id":"supplementaries:sconce_lever","required":false}
-  ]
-}


### PR DESCRIPTION
What a mouthful. Either way, `create:brittle` is a ***block*** tag, not an item tag.

The added item tag currently does nothing. It was likely intended to let Candle Holders & co. be assembled, but it actually doesn't work for the aforementioned reasons.
This PR not only fixes that, but also adds several blocks which were not originally included. I tested with all of them, and it _seems_ to result in no data loss, or something similar. Just makes it so these blocks don't pop right off when the contraption is assembled.


With this PR:

<img alt="With this PR" width=50% src=https://github.com/user-attachments/assets/b1364dff-ab90-4802-a05e-cd989a19c420>

Without:

<img alt="Without" width=50% src=https://github.com/user-attachments/assets/a3937da8-87db-4026-9c62-d9b51088d5a9>

Ash remains completely unrotated which is really funny, and that's because it turns into Falling Ash and remains on top of the contraption as is.

I wasn't able to get it in one take, but **Pancake** is there too because it needs supporting blocks around when disassembling (akin to Cake, which is also tagged), otherwise the pancakes just...

<img alt="Pancakes poofing out of existence" width=50% src=https://github.com/user-attachments/assets/bd01753c-4600-44e4-a049-84444125fa51>

