### PR TITLE
Allow empty timber frames in Create contraptions

### DIFF
--- a/common/src/main/resources/data/create/tags/block/movable_empty_collider.json
+++ b/common/src/main/resources/data/create/tags/block/movable_empty_collider.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    {"id":"#supplementaries:timber_frames","required":false}
+  ]
+}

--- a/common/src/main/resources/data/create/tags/item/movable_empty_collider.json
+++ b/common/src/main/resources/data/create/tags/item/movable_empty_collider.json
@@ -1,7 +1,0 @@
-{
-  "replace": false,
-  "values": [
-    {"id":"#supplementaries:candle_holders","required":false},
-    {"id":"#supplementaries:sconces","required":false}
-  ]
-}


### PR DESCRIPTION
`create:movable_empty_tag` is a ***block*** tag, not an item tag. So, similar to the [prior `create:brittle` item tag](https://github.com/MehVahdJukaar/Supplementaries/pull/1933), this has also been doing nothing. Nor it seems particularly necessary for its intended purpose, as can be seen in the aforementioned PR *(but I may be wrong!)*.

However, what this block tag is necessary for is the **Timber Frame**, **Brace**, and **Cross Brace** because those have no collision when empty and would otherwise be excluded from contraptions ([like how Cobwebs would be](https://wiki.createmod.net/developers/tags#item-tags:~:text=create%3Amovable_empty_collider))

| Without | With this PR |
| --- | --- |
| ![Without](https://i.gyazo.com/bc5197a4379c7f87a45497bd2a42898f.gif) | ![With](https://i.gyazo.com/43dfb24fb5a470319275d821c59e12df.gif) |