### PR TITLE
Fix startup hang: lazy-init MiscUtils.FESTIVITY

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/client/TextUtils.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/client/TextUtils.java
@@ -32,7 +32,7 @@ public class TextUtils {
         float lx = 1 - (2 * 0.125f);
 
         CREDITS.addAll(Minecraft.getInstance().font.split(TextUtil.parseText(text, null), Mth.floor(lx * SCALING_FACTOR)));
-        String b = !MiscUtils.FESTIVITY.isAprilsFool() ? "" :
+        String b = !MiscUtils.getFestivity().isAprilsFool() ? "" :
                 """
                 THE BEE MOVIE§r
 

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/client/renderers/entities/RedMerchantRenderer.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/client/renderers/entities/RedMerchantRenderer.java
@@ -30,7 +30,7 @@ public class RedMerchantRenderer extends MobRenderer<RedMerchantEntity, Villager
     public ResourceLocation getTextureLocation(RedMerchantEntity entity) {
         return entity.getDisplayName().getString().toLowerCase(Locale.ROOT).equals("morshu") ?
                 ModTextures.ORANGE_MERCHANT :
-                MiscUtils.FESTIVITY.isChristmas() ? ModTextures.RED_MERCHANT_CHRISTMAS : ModTextures.RED_MERCHANT;
+                MiscUtils.getFestivity().isChristmas() ? ModTextures.RED_MERCHANT_CHRISTMAS : ModTextures.RED_MERCHANT;
     }
 
     @Override

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/client/renderers/tiles/BlackboardBlockTileRenderer.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/client/renderers/tiles/BlackboardBlockTileRenderer.java
@@ -38,7 +38,7 @@ public class BlackboardBlockTileRenderer implements BlockEntityRenderer<Blackboa
 
     public BlackboardBlockTileRenderer(BlockEntityRendererProvider.Context context) {
         this.mc = Minecraft.getInstance();
-        this.noise = MiscUtils.FESTIVITY.isAprilsFool();
+        this.noise = MiscUtils.getFestivity().isAprilsFool();
     }
 
     @Override

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/client/renderers/tiles/GlobeBlockTileRenderer.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/client/renderers/tiles/GlobeBlockTileRenderer.java
@@ -109,7 +109,7 @@ public class GlobeBlockTileRenderer implements BlockEntityRenderer<GlobeBlockTil
         models.put(GlobeManager.Model.SNOW, special.getChild("snow"));
         models.put(GlobeManager.Model.SHEARED, special.getChild("sheared"));
         INSTANCE = this;
-        this.noise = MiscUtils.FESTIVITY.isAprilsFool();
+        this.noise = MiscUtils.getFestivity().isAprilsFool();
 
     }
 

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/client/renderers/tiles/HourGlassBlockTileRenderer.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/client/renderers/tiles/HourGlassBlockTileRenderer.java
@@ -33,7 +33,7 @@ public class HourGlassBlockTileRenderer implements BlockEntityRenderer<HourGlass
                                   ResourceLocation texture, float height, Direction dir) {
 
         int color = 0xffffff;
-        if (MiscUtils.FESTIVITY.isAprilsFool()) {
+        if (MiscUtils.getFestivity().isAprilsFool()) {
             color = ColorHelper.getRainbowColor(1);
             texture = ModTextures.WHITE_CONCRETE_TEXTURE;
         }

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/client/renderers/tiles/ItemShelfBlockTileRenderer.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/client/renderers/tiles/ItemShelfBlockTileRenderer.java
@@ -56,7 +56,7 @@ public class ItemShelfBlockTileRenderer implements BlockEntityRenderer<ItemShelf
             }
 
             ItemStack stack = tile.getDisplayedItem();
-            if (MiscUtils.FESTIVITY.isAprilsFool()) stack = new ItemStack(Items.SALMON);
+            if (MiscUtils.getFestivity().isAprilsFool()) stack = new ItemStack(Items.SALMON);
             BakedModel model = itemRenderer.getModel(stack, tile.getLevel(), null, 0);
             if (model.usesBlockLight() && ClientConfigs.Blocks.SHELF_TRANSLATE.get()) matrixStackIn.translate(0, -0.25, 0);
 

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/client/renderers/tiles/NoticeBoardBlockTileRenderer.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/client/renderers/tiles/NoticeBoardBlockTileRenderer.java
@@ -178,7 +178,7 @@ public class NoticeBoardBlockTileRenderer implements BlockEntityRenderer<NoticeB
         poseStack.pushPose();
         poseStack.translate(0, 0.5, 0.008);
 
-        if (MiscUtils.FESTIVITY.isAprilsFool()) {
+        if (MiscUtils.getFestivity().isAprilsFool()) {
             float d0 = ColorUtils.getShading(dir.step());
             TextUtils.renderBeeMovie(poseStack, buffer, frontLight, font, d0);
             poseStack.popPose();

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/client/renderers/tiles/PedestalBlockTileRenderer.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/client/renderers/tiles/PedestalBlockTileRenderer.java
@@ -157,7 +157,7 @@ public class PedestalBlockTileRenderer implements BlockEntityRenderer<PedestalBl
             }
 
 
-            if (MiscUtils.FESTIVITY.isAprilsFool()) stack = new ItemStack(Items.DIRT);
+            if (MiscUtils.getFestivity().isAprilsFool()) stack = new ItemStack(Items.DIRT);
             this.itemRenderer.renderStatic(stack, transform, combinedLightIn, combinedOverlayIn, matrixStackIn, bufferIn, tile.getLevel(), 0);
 
             matrixStackIn.popPose();

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/client/renderers/tiles/StatueBlockTileRenderer.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/client/renderers/tiles/StatueBlockTileRenderer.java
@@ -105,7 +105,7 @@ public class StatueBlockTileRenderer implements BlockEntityRenderer<StatueBlockT
         StatueBlockTile.StatuePose pose = tile.getPose();
         ItemStack stack = tile.getDisplayedItem();
 
-        if (MiscUtils.FESTIVITY.isHalloween()) {
+        if (MiscUtils.getFestivity().isHalloween()) {
             this.model.head.visible = false;
             this.model.hat.visible = false;
             if (pose == StatueBlockTile.StatuePose.STANDING) {
@@ -120,8 +120,8 @@ public class StatueBlockTileRenderer implements BlockEntityRenderer<StatueBlockT
                         combinedLightIn, combinedOverlayIn, poseStack, bufferIn, tile.getLevel(), 0);
                 poseStack.popPose();
             }
-        } else if (MiscUtils.FESTIVITY.isChristmas() || MiscUtils.FESTIVITY.isBirthday() ||
-                MiscUtils.FESTIVITY.isAprilsFool()) {
+        } else if (MiscUtils.getFestivity().isChristmas() || MiscUtils.getFestivity().isBirthday() ||
+                MiscUtils.getFestivity().isAprilsFool()) {
             poseStack.pushPose();
             float scale = 0.5f;
             poseStack.translate(0, -1/16f, 0);

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/block/blocks/ClockBlock.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/block/blocks/ClockBlock.java
@@ -73,7 +73,7 @@ public class ClockBlock extends WaterBlock implements EntityBlock {
 
     public static boolean canReadTime(Level level) {
         boolean naturalDim = (level.dimensionType().natural() || CommonConfigs.Tweaks.COMPASS_WORKS_IN_UNNATURAL_DIMENSIONS.get());
-        return naturalDim ^ MiscUtils.FESTIVITY.isAprilsFool();
+        return naturalDim ^ MiscUtils.getFestivity().isAprilsFool();
     }
 
     @Override

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/block/blocks/GlobeBlock.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/block/blocks/GlobeBlock.java
@@ -151,7 +151,7 @@ public class GlobeBlock extends WaterBlock implements EntityBlock, IWashable {
 
     @Override
     public void animateTick(BlockState stateIn, Level level, BlockPos pos, RandomSource rand) {
-        if (MiscUtils.FESTIVITY.isEarthDay() && level.isClientSide) {
+        if (MiscUtils.getFestivity().isEarthDay() && level.isClientSide) {
             int x = pos.getX();
             int y = pos.getY();
             int z = pos.getZ();

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/entities/trades/PresentItemListing.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/entities/trades/PresentItemListing.java
@@ -28,7 +28,7 @@ public record PresentItemListing(ModItemListing original) implements ModItemList
 
         MerchantOffer originalOffer = original.getOffer(entity, random);
         if (originalOffer == null) return null;
-        if (MiscUtils.FESTIVITY.isChristmas() && CommonConfigs.Functional.PRESENT_ENABLED.get()) {
+        if (MiscUtils.getFestivity().isChristmas() && CommonConfigs.Functional.PRESENT_ENABLED.get()) {
             Block randomPresent = ModRegistry.PRESENTS.get(DyeColor.values()[
                     random.nextInt(DyeColor.values().length)]).get();
             PresentBlockTile dummyTile = new PresentBlockTile(BlockPos.ZERO,

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/misc/globe/GlobeTextureGenerator.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/misc/globe/GlobeTextureGenerator.java
@@ -349,9 +349,9 @@ public class GlobeTextureGenerator {
         generateMushrooms();
         generateIcebergs2();
 
-        if (MiscUtils.FESTIVITY.isChristmas()) {
+        if (MiscUtils.getFestivity().isChristmas()) {
             christmas();
-        } else if (MiscUtils.FESTIVITY.isEarthDay()) {
+        } else if (MiscUtils.getFestivity().isEarthDay()) {
             meltice();
         }
     }

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/misc/songs/SongsManager.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/misc/songs/SongsManager.java
@@ -96,7 +96,7 @@ public class SongsManager extends SimpleJsonResourceReloadListener {
     }
 
     public static Song setCurrentlyPlaying(UUID id, String songKey) {
-        if (MiscUtils.FESTIVITY.isAprilsFool()) songKey = "rickroll";
+        if (MiscUtils.getFestivity().isAprilsFool()) songKey = "rickroll";
         Song song = SONGS.getOrDefault(songKey, Song.EMPTY);
         CURRENTLY_PAYING.put(id, song);
         song.validatePlayReady();
@@ -109,7 +109,7 @@ public class SongsManager extends SimpleJsonResourceReloadListener {
 
     @NotNull
     private static String selectRandomSong(RandomSource random) {
-        if (MiscUtils.FESTIVITY.isChristmas() && random.nextFloat() > 0.8) {
+        if (MiscUtils.getFestivity().isChristmas() && random.nextFloat() > 0.8) {
             return CAROLS.get(random.nextInt(CAROLS.size()));
         }
         Optional<WeightedEntry.Wrapper<String>> song = WeightedRandom.getRandomItem(random, SONG_WEIGHTED_LIST);

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/common/utils/MiscUtils.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/common/utils/MiscUtils.java
@@ -139,7 +139,14 @@ public class MiscUtils {
         }
     }
 
-    public static final Festivity FESTIVITY = Festivity.compute();
+    private static Festivity cachedFestivity;
+
+    public static Festivity getFestivity() {
+        if (cachedFestivity == null) {
+            cachedFestivity = Festivity.compute();
+        }
+        return cachedFestivity;
+    }
 
     public static boolean isSword(Item i) {
         if (i.builtInRegistryHolder().is(ModTags.STATUE_SWORDS)) return true;

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/dynamicpack/ModClientDynamicResources.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/dynamicpack/ModClientDynamicResources.java
@@ -105,7 +105,7 @@ public class ModClientDynamicResources extends DynamicClientResourceProvider {
                     ResType.BLOCK_TEXTURES.getPath(Supplementaries.res("gold_gate_top")), false);
         }
 
-        if (MiscUtils.FESTIVITY.isChristmas()) {
+        if (MiscUtils.getFestivity().isChristmas()) {
             sink.copyResource(manager, ResType.ITEM_TEXTURES.getPath(Supplementaries.res("party_hat")),
                     ResType.ITEM_TEXTURES.getPath(Supplementaries.res("party_hat_christmas")), false);
         }

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/dynamicpack/MojangNeedsToAddMoreCopper.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/dynamicpack/MojangNeedsToAddMoreCopper.java
@@ -23,7 +23,7 @@ public class MojangNeedsToAddMoreCopper {
 
 
     public static void run(ResourceManager manager, ResourceSink sink) {
-        if (!MiscUtils.FESTIVITY.isAprilsFool()) return;
+        if (!MiscUtils.getFestivity().isAprilsFool()) return;
 
         try (TextureImage c0 = TextureImage.open(manager, RPUtils.findFirstBlockTextureLocation(manager, Blocks.COPPER_BLOCK));
              TextureImage c1 = TextureImage.open(manager, RPUtils.findFirstBlockTextureLocation(manager, Blocks.EXPOSED_COPPER));
@@ -121,7 +121,7 @@ public class MojangNeedsToAddMoreCopper {
     }
 
     public static void runTranslations(AfterLanguageLoadEvent lang) {
-        if (!MiscUtils.FESTIVITY.isAprilsFool()) return;
+        if (!MiscUtils.getFestivity().isAprilsFool()) return;
         Random random = new Random();
         try {
             @Deprecated(forRemoval = true)

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/mixins/RedMerchantSpawnerMixin.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/mixins/RedMerchantSpawnerMixin.java
@@ -129,7 +129,7 @@ public abstract class RedMerchantSpawnerMixin {
         diff *= dragon;
 
         //ho ho ho
-        if (MiscUtils.FESTIVITY.isChristmas()) diff *= 15;
+        if (MiscUtils.getFestivity().isChristmas()) diff *= 15;
 
         return diff;
     }

--- a/common/src/main/java/net/mehvahdjukaar/supplementaries/reg/ClientRegistry.java
+++ b/common/src/main/java/net/mehvahdjukaar/supplementaries/reg/ClientRegistry.java
@@ -299,7 +299,7 @@ public class ClientRegistry {
                 (stack, world, entity, s) -> TrappedPresentBlockTile.isPrimed(stack) ? 1.0F : 0F));
 
         ItemProperties.register(ModRegistry.CANDY_ITEM.get(), Supplementaries.res("wrapping"),
-                (stack, world, entity, s) -> MiscUtils.FESTIVITY.getCandyWrappingIndex());
+                (stack, world, entity, s) -> MiscUtils.getFestivity().getCandyWrappingIndex());
 
         ItemProperties.register(ModRegistry.QUIVER_ITEM.get(), Supplementaries.res("dyed"),
                 (stack, world, entity, s) -> stack.has(DataComponents.DYED_COLOR) ? 1 : 0);


### PR DESCRIPTION
## Summary
- `MiscUtils.FESTIVITY` is a `static final` field eagerly computed at class load time via `Festivity.compute()`
- `compute()` reads `ClientConfigs.General.UNFUNNY.get()`, which throws `IllegalStateException` if configs aren't loaded yet
- If `MiscUtils` is classloaded before configs are ready (e.g. triggered by block entity renderer constructors during `EntityRenderers.createEntityRenderers()`), this hangs startup
- This is a race condition — it depends on mod loading order, so it may only reproduce with certain modpack configurations (confirmed in ATM10)

## Fix
- Replace the eager `static final` field with a lazy `getFestivity()` method that computes on first access, when configs are guaranteed to be loaded
- All 18 internal references to `MiscUtils.FESTIVITY` updated to use `MiscUtils.getFestivity()`