### PR TITLE
Fixed Depth Gauges from Caverns and Chasms not being properly counted as an altimeter

### DIFF
--- a/common/src/main/resources/data/supplementaries/tags/item/altimeters.json
+++ b/common/src/main/resources/data/supplementaries/tags/item/altimeters.json
@@ -3,6 +3,6 @@
   "values": [
     {"id":"spelunkery:depth_gauge","required":false},
     {"id":"supplementaries:altimeter","required":true},
-    {"id":"caverns_and_chasms:altimeter","required":false}
+    {"id":"caverns_and_chasms:depth_gauge","required":false}
   ]
 }


### PR DESCRIPTION
supplementaries:altimeters used caverns_and_chasms:altimeter instead of the actual ID caverns_and_chasms:depth_gauge